### PR TITLE
Dont submit resources with non-xloader formats with CLI

### DIFF
--- a/ckanext/xloader/cli.py
+++ b/ckanext/xloader/cli.py
@@ -39,11 +39,6 @@ class xloaderCommand(cli.CkanCommand):
                 --ignore-format - submit resources even if they have a format
                 not in the configured ckanext.xloader.formats
 
-                --skip-if-hash-is-unchanged - don't reload data files that
-                are unchanged since the previous load. (It still submits them,
-                but once xloader has download the file, if the hash is the same
-                as resource.hash it will skip the reload into DataStore)
-
         xloader status
               Shows status of jobs
     '''
@@ -65,12 +60,6 @@ class xloaderCommand(cli.CkanCommand):
         self.parser.add_option('--dry-run',
                                action='store_true', default=False,
                                help='Don\'t actually submit anything')
-        self.parser.add_option('--skip-if-hash-is-unchanged',
-                               action='store_true', default=False,
-                               help='Don\'t reloading data files that are '
-                               'are unchanged since the previous load (it '
-                               'still submits it - xloader will download the '
-                               'file and compare the hash with resource.hash)')
 
     def command(self):
         if not self.args:
@@ -199,10 +188,9 @@ class xloaderCommand(cli.CkanCommand):
               '{indent}           url={r[url]}\n'
               '{indent}           format={r[format]}'
               .format(dataset=dataset_ref, r=resource, indent=' ' * indent))
-        ignore_hash = not self.options.skip_if_hash_is_unchanged
         data_dict = {
             'resource_id': resource['id'],
-            'ignore_hash': ignore_hash,
+            'ignore_hash': True,
         }
         if self.options.dry_run:
             print(' ' * indent + '(not submitted - dry-run)')

--- a/ckanext/xloader/controllers.py
+++ b/ckanext/xloader/controllers.py
@@ -46,4 +46,5 @@ class ResourceDataController(p.toolkit.BaseController):
                                 extra_vars={
                                     'status': xloader_status,
                                     'resource': p.toolkit.c.resource,
+                                    'pkg_dict': p.toolkit.c.pkg_dict,
                                 })

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -235,13 +235,14 @@ def xloader_data_into_datastore_(input, job_dict):
     file_hash = m.hexdigest()
     tmp_file.seek(0)
 
+    # hash isn't actually stored, so this is a bit worthless at the moment
     if (resource.get('hash') == file_hash
             and not data.get('ignore_hash')):
         logger.info('Ignoring resource - the file hash hasn\'t changed: '
                     '{hash}.'.format(hash=file_hash))
         return
     logger.info('File hash: {}'.format(file_hash))
-    resource['hash'] = file_hash
+    resource['hash'] = file_hash  # TODO write this back to the actual resource
 
     # Load it
     logger.info('Loading CSV')


### PR DESCRIPTION
The CLI now doesn't send non-configured formats (e.g. PDFs), which brings it into line with the automated submissions when you add a resource to CKAN.

If you really want to submit PDFs etc then you can use the `--ignore-format` parameter
```
paster --plugin=xloader xloader submit all --ignore-format
```

Also a couple of change to options:

`--dry-run` added

`--force` removed - it never did anything (files are always reloaded since hash checking is not working)

I've also done some refactoring in the CLI code.