### PR TITLE
convert values to string before encoding

### DIFF
--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -63,7 +63,7 @@ def load_csv(csv_filepath, resource_id, mimetype='text/csv', logger=None):
         header_offset, headers = messytables.headers_guess(row_set.sample)
 
     # Some headers might have been converted from strings to floats and such.
-    headers = [unidecode(header) for header in headers]
+    headers = encode_headers(headers)
 
     # Guess the delimiter used in the file
     with open(csv_filepath, 'r') as f:
@@ -292,7 +292,7 @@ def load_table(table_filepath, resource_id, mimetype='text/csv', logger=None):
                 for f in existing.get('fields', []) if 'info' in f)
 
         # Some headers might have been converted from strings to floats and such.
-        headers = [unidecode(header) for header in headers]
+        headers = encode_headers(headers)
 
         row_set.register_processor(messytables.headers_processor(headers))
         row_set.register_processor(messytables.offset_processor(offset + 1))
@@ -391,6 +391,17 @@ def get_types():
     #TYPES = web.app.config.get('TYPES', _TYPES)
     TYPE_MAPPING = config.get('TYPE_MAPPING', _TYPE_MAPPING)
     return _TYPES, TYPE_MAPPING
+
+
+def encode_headers(headers):
+    encoded_headers = []
+    for header in headers:
+        try:
+            encoded_headers.append(unidecode(header))
+        except AttributeError:
+            encoded_headers.append(unidecode(str(header)))
+
+    return encoded_headers
 
 
 def chunky(iterable, n):

--- a/ckanext/xloader/tests/test_loader.py
+++ b/ckanext/xloader/tests/test_loader.py
@@ -299,6 +299,24 @@ class TestLoadCsv(TestLoadBase):
             "'-01':2 '-03':3 '00':4,5,6 '2011':1 '5':7"
             )
 
+    def test_encode_headers(self):
+        test_string_headers = [u'id', u'namé']
+        test_float_headers = [u'id', u'näme', 2.0]
+        test_int_headers = [u'id', u'nóm', 3]
+        test_result_string_headers = loader.encode_headers(test_string_headers)
+        test_result_float_headers = loader.encode_headers(test_float_headers)
+        test_result_int_headers = loader.encode_headers(test_int_headers)
+
+        assert_in('id', test_result_string_headers)
+        assert_in('name', test_result_string_headers)
+        assert_in('id', test_result_float_headers)
+        assert_in('name', test_result_float_headers)
+        assert_in('2.0', test_result_float_headers)
+        assert_in('id', test_result_int_headers)
+        assert_in('nom', test_result_int_headers)
+        assert_in('3', test_result_int_headers)
+
+
 class TestLoadUnhandledTypes(TestLoadBase):
 
     def test_kml(self):


### PR DESCRIPTION
When column-headers contain floats the encoding fails as floats do not have an encode-function.

Further explanation: When a file with floats in one of the header-columns, the import failed with the error message `AttributeError: 'float' object has no attribute 'encode'`
Not sure, if my approach either has side-effects or if this is the correct approach but my import with specified file works fine after this change.