### PR TITLE
Deal with UniDecodeError

### DIFF
--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -479,11 +479,11 @@ class StoringHandler(logging.Handler):
         try:
             # Turn strings into unicode to stop SQLAlchemy
             # "Unicode type received non-unicode bind param value" warnings.
-            message = unicode(record.getMessage())
-            level = unicode(record.levelname)
-            module = unicode(record.module)
-            funcName = unicode(record.funcName)
-
+            message = self._safe_encode(record.getMessage())
+            level = self._safe_encode(record.levelname)
+            module = self._safe_encode(record.module)
+            funcName = self._safe_encode(record.funcName)
+            
             conn.execute(db.LOGS_TABLE.insert().values(
                 job_id=self.task_id,
                 timestamp=datetime.datetime.now(),
@@ -494,6 +494,12 @@ class StoringHandler(logging.Handler):
                 lineno=record.lineno))
         finally:
             conn.close()
+
+    def _safe_encode(self, obj):
+        try:
+            return unicode(obj)
+        except UnicodeDecodeError:
+            return obj
 
 
 class DatetimeJsonEncoder(json.JSONEncoder):

--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -63,7 +63,7 @@ def load_csv(csv_filepath, resource_id, mimetype='text/csv', logger=None):
         header_offset, headers = messytables.headers_guess(row_set.sample)
 
     # Some headers might have been converted from strings to floats and such.
-    headers = [unidecode(header) for header in headers]
+    headers = encode_headers(headers)
 
     # Guess the delimiter used in the file
     with open(csv_filepath, 'r') as f:
@@ -292,7 +292,7 @@ def load_table(table_filepath, resource_id, mimetype='text/csv', logger=None):
                 for f in existing.get('fields', []) if 'info' in f)
 
         # Some headers might have been converted from strings to floats and such.
-        headers = [unidecode(header) for header in headers]
+        headers = encode_headers(headers)
 
         row_set.register_processor(messytables.headers_processor(headers))
         row_set.register_processor(messytables.offset_processor(offset + 1))
@@ -391,6 +391,17 @@ def get_types():
     #TYPES = web.app.config.get('TYPES', _TYPES)
     TYPE_MAPPING = config.get('TYPE_MAPPING', _TYPE_MAPPING)
     return _TYPES, TYPE_MAPPING
+
+
+def encode_headers(headers):
+    encoded_headers = []
+    for header in headers:
+        try:
+            encoded_headers.append(unidecode(header))
+        except AttributeError:
+            encoded_headers.append(unidecode(str(header)))
+
+    return encoded_headers
 
 
 def chunky(iterable, n):

--- a/ckanext/xloader/tests/test_loader.py
+++ b/ckanext/xloader/tests/test_loader.py
@@ -299,6 +299,24 @@ class TestLoadCsv(TestLoadBase):
             "'-01':2 '-03':3 '00':4,5,6 '2011':1 '5':7"
             )
 
+    def test_encode_headers(self):
+        test_string_headers = [u'id', u'namé']
+        test_float_headers = [u'id', u'näme', 2.0]
+        test_int_headers = [u'id', u'nóm', 3]
+        test_result_string_headers = loader.encode_headers(test_string_headers)
+        test_result_float_headers = loader.encode_headers(test_float_headers)
+        test_result_int_headers = loader.encode_headers(test_int_headers)
+
+        assert_in('id', test_result_string_headers)
+        assert_in('name', test_result_string_headers)
+        assert_in('id', test_result_float_headers)
+        assert_in('name', test_result_float_headers)
+        assert_in('2.0', test_result_float_headers)
+        assert_in('id', test_result_int_headers)
+        assert_in('nom', test_result_int_headers)
+        assert_in('3', test_result_int_headers)
+
+
 class TestLoadUnhandledTypes(TestLoadBase):
 
     def test_kml(self):


### PR DESCRIPTION
When uploading a csv produces an error with `Error during the load into PostgreSQL` and the error-result contains objects that can not be decoded, a UniDecodeError is thrown and prevents the DataPusher-Mechanism from stepping in. 

Is there are cleaner and/or more pythonic ways to solve this? I'd be very happy to get some feedback even though this only fixes the outdated datapusher-logic.