### PR TITLE
Fix for percent in column name

### DIFF
--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -558,7 +558,10 @@ def _create_fulltext_trigger(connection, resource_id):
 
 
 def identifier(s):
-    return u'"' + s.replace(u'"', u'""').replace(u'\0', '') + u'"'
+    # "%" needs to be escaped, otherwise connection.execute thinks it is for
+    # substituting a bind parameter
+    return u'"' + s.replace(u'"', u'""').replace(u'\0', '').replace('%', '%%')\
+        + u'"'
 
 
 def literal_string(s):

--- a/ckanext/xloader/tests/samples/column_names.csv
+++ b/ckanext/xloader/tests/samples/column_names.csv
@@ -1,0 +1,7 @@
+d@t$e,t^e&m*pe!r(a)ture,place%
+2011-01-01,1,Galway
+2011-01-02,-1,Galway
+2011-01-03,0,Galway
+2011-01-01,6,Berkeley
+,,Berkeley
+2011-01-03,5,

--- a/ckanext/xloader/tests/samples/column_names.csv
+++ b/ckanext/xloader/tests/samples/column_names.csv
@@ -1,4 +1,4 @@
-d@t$e,t^e&m*pe!r(a)ture,place%
+d@t$e,t^e&m*pe!r(a)t?u:r%%e,p\l/a[c{e%
 2011-01-01,1,Galway
 2011-01-02,-1,Galway
 2011-01-03,0,Galway

--- a/ckanext/xloader/tests/test_loader.py
+++ b/ckanext/xloader/tests/test_loader.py
@@ -340,7 +340,7 @@ class TestLoadCsv(TestLoadBase):
 
         assert_equal(
             self._get_column_names('test1')[2:],
-            [u'd@t$e', u't^e&m*pe!r(a)ture', u'place%'])
+            [u'd@t$e', u't^e&m*pe!r(a)t?u:r%%e', ur'p\l/a[c{e%'])
         assert_equal(self._get_records('test1')[0],
                      (1, u'2011-01-01', u'1', u'Galway'))
 

--- a/ckanext/xloader/tests/test_loader.py
+++ b/ckanext/xloader/tests/test_loader.py
@@ -47,7 +47,7 @@ class TestLoadBase(util.PluginsMixin):
         c = self.Session.connection()
         if exclude_full_text_column:
             cols = self._get_column_names(table_name)
-            cols = ', '.join('"{}"'.format(col) for col in cols
+            cols = ', '.join(loader.identifier(col) for col in cols
                              if col != '_full_text')
         else:
             cols = '*'
@@ -330,6 +330,19 @@ class TestLoadCsv(TestLoadBase):
         assert_in('id', test_result_int_headers)
         assert_in('nom', test_result_int_headers)
         assert_in('3', test_result_int_headers)
+
+    def test_column_names(self):
+        csv_filepath = get_sample_filepath('column_names.csv')
+        resource_id = 'test1'
+        factories.Resource(id=resource_id)
+        loader.load_csv(csv_filepath, resource_id=resource_id,
+                        mimetype='text/csv', logger=PrintLogger())
+
+        assert_equal(
+            self._get_column_names('test1')[2:],
+            [u'd@t$e', u't^e&m*pe!r(a)ture', u'place%'])
+        assert_equal(self._get_records('test1')[0],
+                     (1, u'2011-01-01', u'1', u'Galway'))
 
 
 class TestLoadUnhandledTypes(TestLoadBase):


### PR DESCRIPTION
Fixes #65 

TODO Still considering whether it's better to do this in the session.execute line instead, like is done in datastore's backend.

However datastore doesn't handle the percent perfectly yet, so that needs a fix too.