### PR TITLE
Fix build - master is python3 requirements

### DIFF
--- a/bin/travis-build.bash
+++ b/bin/travis-build.bash
@@ -33,7 +33,12 @@ then
 fi
 
 python setup.py develop
-pip install -r requirements.txt
+if [ -f requirements-py2.txt ]
+then
+    pip install -r requirements-py2.txt
+else
+    pip install -r requirements.txt
+fi
 pip install -r dev-requirements.txt
 cd -
 

--- a/ckanext/xloader/tests/test_jobs.py
+++ b/ckanext/xloader/tests/test_jobs.py
@@ -13,7 +13,12 @@ import mock
 import responses
 from sqlalchemy import MetaData, Table
 from sqlalchemy.sql import select
-from pylons import config
+
+import ckan.plugins as p
+try:
+    config = p.toolkit.config
+except AttributeError:
+    from pylons import config
 
 from ckanext.xloader import jobs
 from ckanext.xloader import db as jobs_db


### PR DESCRIPTION
Master now defaults to python3 requirements, without pylons