### PR TITLE
Fix the retry of getting resource from CKAN

### DIFF
--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -13,7 +13,7 @@ import requests
 from rq import get_current_job
 import sqlalchemy as sa
 
-from ckan.plugins.toolkit import get_action
+from ckan.plugins.toolkit import get_action, ObjectNotFound
 try:
     from ckan.plugins.toolkit import config
 except ImportError:
@@ -136,7 +136,7 @@ def xloader_data_into_datastore_(input, job_dict):
 
     try:
         resource, dataset = get_resource_and_dataset(resource_id)
-    except JobError, e:
+    except (JobError, ObjectNotFound) as e:
         # try again in 5 seconds just in case CKAN is slow at adding resource
         time.sleep(5)
         resource, dataset = get_resource_and_dataset(resource_id)


### PR DESCRIPTION
Fixes #93 

If CKAN hasn't quite added the resource yet, then we expect a 404,
causing a NotFound exception. So that is now caught and causes a delayed
retry. I'll keep JobError in there too, in case CKAN is being
unresponsive or connectivity is down for a moment.