### PR TITLE
CKAN 2.9 fixes

### DIFF
--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -491,8 +491,9 @@ def get_resource_and_dataset(resource_id):
     """
     Gets available information about the resource and its dataset from CKAN
     """
-    res_dict = get_action('resource_show')(None, {'id': resource_id})
-    pkg_dict = get_action('package_show')(None, {'id': res_dict['package_id']})
+    context = {'ignore_auth': True}
+    res_dict = get_action('resource_show')(context, {'id': resource_id})
+    pkg_dict = get_action('package_show')(context, {'id': res_dict['package_id']})
     return res_dict, pkg_dict
 
 

--- a/ckanext/xloader/plugin.py
+++ b/ckanext/xloader/plugin.py
@@ -39,7 +39,6 @@ class XLoaderFormats(object):
 class xloaderPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IConfigurer)
     plugins.implements(plugins.IConfigurable)
-    plugins.implements(plugins.IDomainObjectModification)
     plugins.implements(plugins.IResourceUrlChange)
     plugins.implements(plugins.IActions)
     plugins.implements(plugins.IAuthFunctions)
@@ -87,60 +86,59 @@ class xloaderPlugin(plugins.SingletonPlugin):
                                 'See ckanext-xloader\'s README.rst for more '
                                 'details.')
 
-    # IDomainObjectModification
     # IResourceUrlChange
 
-    def notify(self, entity, operation=None):
-        if isinstance(entity, model.Resource):
-            if (operation == model.domain_object.DomainObjectOperation.new or
-                    not operation):
-                # if operation is None, resource URL has been changed, as
-                # the notify function in IResourceUrlChange only takes
-                # 1 parameter
-                context = {'model': model, 'ignore_auth': True,
-                           'defer_commit': True}
-                if not XLoaderFormats.is_it_an_xloader_format(entity.format):
-                    log.debug('Skipping xloading resource {r.id} because '
-                              'format "{r.format}" is not configured to be '
-                              'xloadered'
-                              .format(r=entity))
-                    return
-                if entity.url_type in ('datapusher', 'xloader'):
-                    log.debug('Skipping xloading resource {r.id} because '
-                              'url_type "{r.url_type}" means resource.url '
-                              'points to the datastore already, so loading '
-                              'would be circular.'.format(r=entity))
-                    return
+    def notify(self, resource):
+        context = {
+            u'model': model,
+            u'ignore_auth': True,
+        }
+        resource_dict = toolkit.get_action(u'resource_show')(
+            context, {
+            u'id': resource.id,
+            }
+        )
+        self._submit_to_xloader(resource_dict)
 
-                # try:
-                #     task = p.toolkit.get_action('task_status_show')(
-                #         context, {
-                #             'entity_id': entity.id,
-                #             'task_type': 'datapusher',
-                #             'key': 'datapusher'}
-                #     )
-                #     if task.get('state') == 'pending':
-                #         # There already is a pending DataPusher submission,
-                #         # skip this one ...
-                #         log.debug(
-                #             'Skipping DataPusher submission for '
-                #             'resource {0}'.format(entity.id))
-                #         return
-                # except p.toolkit.ObjectNotFound:
-                #     pass
+    # IResourceController
 
-                try:
-                    log.debug('Submitting resource {0} to be xloadered'
-                              .format(entity.id))
-                    p.toolkit.get_action('xloader_submit')(context, {
-                        'resource_id': entity.id,
-                        'ignore_hash': self.ignore_hash,
-                    })
-                except p.toolkit.ValidationError as e:
-                    # If xloader is offline, we want to catch error instead
-                    # of raising otherwise resource save will fail with 500
-                    log.critical(e)
-                    pass
+    def after_create(self, context, resource_dict):
+
+        self._submit_to_xloader(resource_dict)
+
+    def _submit_to_xloader(self, resource_dict):
+
+        context = {'model': model, 'ignore_auth': True,
+                   'defer_commit': True}
+        if not XLoaderFormats.is_it_an_xloader_format(resource_dict['format']):
+            log.debug('Skipping xloading resource {id} because '
+                      'format "{format}" is not configured to be '
+                      'xloadered'
+                      .format(
+                          id=resource_dict['id'],
+                          format=resource_dict['format']))
+            return
+        if resource_dict['url_type'] in ('datapusher', 'xloader'):
+            log.debug('Skipping xloading resource {id} because '
+                      'url_type "{url_type}" means resource.url '
+                      'points to the datastore already, so loading '
+                      'would be circular.'.format(
+                          id=resource_dict['id'],
+                          url_type=resource_dict['url_type']))
+            return
+
+        try:
+            log.debug('Submitting resource {0} to be xloadered'
+                      .format(resource_dict['id']))
+            p.toolkit.get_action('xloader_submit')(context, {
+                'resource_id': resource_dict['id'],
+                'ignore_hash': self.ignore_hash,
+            })
+        except p.toolkit.ValidationError as e:
+            # If xloader is offline, we want to catch error instead
+            # of raising otherwise resource save will fail with 500
+            log.critical(e)
+            pass
 
     # IActions
 


### PR DESCRIPTION
This includes two 2.9 fixes (it does not include python 3 support related changes)

Commit messages have all details but the summary is:

1. Pass ignore_auth on action calls
2. Refactor plugin interfaces to avoid transaction error (Same as  ckan/ckan#5173)