### PR TITLE
requirements.txt needs the six module to be >= 1.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 messytables==0.15.2
 Unidecode==1.0.22
-six
+six>=1.12.0


### PR DESCRIPTION
Fixes https://github.com/ckan/ckanext-xloader/issues/125

`pip-requirements.txt` had the six module requirement to be >= 1.12 but not `requirements.txt`

The 'ensure_text' attribute was added to `six 1.12`