### PR TITLE
Send user context to the resource patch function in patch.py

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Install requirements
         run: pip install flake8 pycodestyle
       - name: Check syntax
-        run: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics --exclude ckan,.git/
+        run: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics --extend-exclude ckan
       #- name: Run flake8
       #  run: flake8 . --count --max-line-length=127 --statistics --exclude ckan
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Install requirements
         run: pip install flake8 pycodestyle
       - name: Check syntax
-        run: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics --exclude ckan
+        run: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics --exclude ckan,.git/
       #- name: Run flake8
       #  run: flake8 . --count --max-line-length=127 --statistics --exclude ckan
 

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -481,7 +481,7 @@ def update_resource(resource, patch_only=False):
     """
     action = 'resource_update' if not patch_only else 'resource_patch'
     from ckan import model
-    #user = get_action('get_site_user')({'model': model, 'ignore_auth': True}, {})
+    user = get_action('get_site_user')({'model': model, 'ignore_auth': True}, {})
     #context = {'model': model, 'session': model.Session, 'ignore_auth': True, 
     #           'user': user['name'], 'auth_user_obj': None}
     context = {'model': model, 'session': model.Session, 'ignore_auth': True}

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -483,7 +483,8 @@ def update_resource(resource, patch_only=False):
     from ckan import model
     user = get_action('get_site_user')({'model': model, 'ignore_auth': True}, {})
     context = {'model': model, 'session': model.Session, 'ignore_auth': True, 
-    #           'user': user['name'], 'auth_user_obj': None}
+               'user': user['name'], 'auth_user_obj': None}
+    context =
     context = {'model': model, 'session': model.Session, 'ignore_auth': True}
     get_action(action)(context, resource)
 

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -482,7 +482,8 @@ def update_resource(resource, patch_only=False):
     action = 'resource_update' if not patch_only else 'resource_patch'
     from ckan import model
     user = get_action('get_site_user')({'model': model, 'ignore_auth': True}, {})
-    context = {'model': model, 'session': model.Session, 'ignore_auth': True, 'user': user['name'], 'auth_user_obj': None}           
+    context = {'model': model, 'session': model.Session, 'ignore_auth': True, 
+               'user': user['name'], 'auth_user_obj': None}           
     get_action(action)(context, resource)
 
 

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -481,8 +481,8 @@ def update_resource(resource, patch_only=False):
     """
     action = 'resource_update' if not patch_only else 'resource_patch'
     from ckan import model
-    site_user = get_action('get_site_user')({'model': model, 'ignore_auth': True}, {})
-    context = {'model': model, 'session': model.Session, 'ignore_auth': True, 'user': site_user['name'], 'auth_user_obj': None}           
+    user = get_action('get_site_user')({'model': model, 'ignore_auth': True}, {})
+    context = {'model': model, 'session': model.Session, 'ignore_auth': True, 'user': user['name'], 'auth_user_obj': None}           
     get_action(action)(context, resource)
 
 

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -482,8 +482,7 @@ def update_resource(resource, patch_only=False):
     action = 'resource_update' if not patch_only else 'resource_patch'
     from ckan import model
     site_user = get_action('get_site_user')({'model': model, 'ignore_auth': True}, {})
-    context = {'model': model, 'session': model.Session, 'ignore_auth': True, 
-               'user': site_user['name'], 'auth_user_obj': None}
+    context = {'model': model, 'session': model.Session, 'ignore_auth': True, 'user': site_user['name'], 'auth_user_obj': None}           
     get_action(action)(context, resource)
 
 

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -482,7 +482,7 @@ def update_resource(resource, patch_only=False):
     action = 'resource_update' if not patch_only else 'resource_patch'
     from ckan import model
     site_user = get_action('get_site_user')({'model': model, 'ignore_auth': True}, {})
-    context = {'model': model, 'session': model.Session, 'ignore_auth': True,
+    context = {'model': model, 'session': model.Session, 'ignore_auth': True, 
                'user': site_user['name'], 'auth_user_obj': None}
     get_action(action)(context, resource)
 

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -481,7 +481,9 @@ def update_resource(resource, patch_only=False):
     """
     action = 'resource_update' if not patch_only else 'resource_patch'
     from ckan import model
-    context = {'model': model, 'session': model.Session, 'ignore_auth': True}
+    site_user = get_action('get_site_user')({'model': model, 'ignore_auth': True}, {})
+    context = {'model': model, 'session': model.Session, 'ignore_auth': True
+               'user': site_user['name'], 'auth_user_obj': None}
     get_action(action)(context, resource)
 
 

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -482,7 +482,7 @@ def update_resource(resource, patch_only=False):
     action = 'resource_update' if not patch_only else 'resource_patch'
     from ckan import model
     site_user = get_action('get_site_user')({'model': model, 'ignore_auth': True}, {})
-    context = {'model': model, 'session': model.Session, 'ignore_auth': True
+    context = {'model': model, 'session': model.Session, 'ignore_auth': True,
                'user': site_user['name'], 'auth_user_obj': None}
     get_action(action)(context, resource)
 

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -483,7 +483,7 @@ def update_resource(resource, patch_only=False):
     from ckan import model
     user = get_action('get_site_user')({'model': model, 'ignore_auth': True}, {})
     context = {'model': model, 'session': model.Session, 'ignore_auth': True, 
-               'user': user['name'], 'auth_user_obj': None}           
+               'user': user['name'], 'auth_user_obj': None}
     get_action(action)(context, resource)
 
 

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -484,8 +484,7 @@ def update_resource(resource, patch_only=False):
     user = get_action('get_site_user')({'model': model, 'ignore_auth': True}, {})
     context = {'model': model, 'session': model.Session, 'ignore_auth': True, 
                'user': user['name'], 'auth_user_obj': None}
-    context =
-    context = {'model': model, 'session': model.Session, 'ignore_auth': True}
+    #context = {'model': model, 'session': model.Session, 'ignore_auth': True}
     get_action(action)(context, resource)
 
 

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -482,9 +482,8 @@ def update_resource(resource, patch_only=False):
     action = 'resource_update' if not patch_only else 'resource_patch'
     from ckan import model
     user = get_action('get_site_user')({'model': model, 'ignore_auth': True}, {})
-    context = {'model': model, 'session': model.Session, 'ignore_auth': True, 
+    context = {'model': model, 'session': model.Session, 'ignore_auth': True,
                'user': user['name'], 'auth_user_obj': None}
-    #context = {'model': model, 'session': model.Session, 'ignore_auth': True}
     get_action(action)(context, resource)
 
 

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -482,7 +482,7 @@ def update_resource(resource, patch_only=False):
     action = 'resource_update' if not patch_only else 'resource_patch'
     from ckan import model
     user = get_action('get_site_user')({'model': model, 'ignore_auth': True}, {})
-    #context = {'model': model, 'session': model.Session, 'ignore_auth': True, 
+    context = {'model': model, 'session': model.Session, 'ignore_auth': True, 
     #           'user': user['name'], 'auth_user_obj': None}
     context = {'model': model, 'session': model.Session, 'ignore_auth': True}
     get_action(action)(context, resource)

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -481,9 +481,10 @@ def update_resource(resource, patch_only=False):
     """
     action = 'resource_update' if not patch_only else 'resource_patch'
     from ckan import model
-    user = get_action('get_site_user')({'model': model, 'ignore_auth': True}, {})
-    context = {'model': model, 'session': model.Session, 'ignore_auth': True, 
-               'user': user['name'], 'auth_user_obj': None}
+    #user = get_action('get_site_user')({'model': model, 'ignore_auth': True}, {})
+    #context = {'model': model, 'session': model.Session, 'ignore_auth': True, 
+    #           'user': user['name'], 'auth_user_obj': None}
+    context = {'model': model, 'session': model.Session, 'ignore_auth': True}
     get_action(action)(context, resource)
 
 


### PR DESCRIPTION
Fixes Issue: https://github.com/ckan/ckanext-xloader/issues/126

This fixes a problem where a "KeyError: 'user'" error occurs during the update of the resource status - the context passed is missing "user info" and so errors out