### PR TITLE
Document ssl_verify config

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -260,6 +260,11 @@ Configuration:
     # not be loaded into the datastore.
     ckanext.xloader.max_excerpt_lines = 100
 
+    # Requests verifies SSL certificates for HTTPS requests. Setting verify to
+    # False should only be enabled during local development or testing. Default
+    # to True.
+    ckanext.xloader.ssl_verify = True
+
 ------------------------
 Developer installation
 ------------------------

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -28,10 +28,7 @@ from . import loader
 from . import db
 from .job_exceptions import JobError, HTTPError, DataTooBigError, FileCouldNotBeLoadedError
 
-if config.get('ckanext.xloader.ssl_verify') in ['False', 'FALSE', '0', False, 0]:
-    SSL_VERIFY = False
-else:
-    SSL_VERIFY = True
+SSL_VERIFY = asbool(config.get('ckanext.xloader.ssl_verify', True))
 if not SSL_VERIFY:
     requests.packages.urllib3.disable_warnings()
 


### PR DESCRIPTION
Adding `ckanext.xloader.ssl_verify` config to the README file.

Also I did a small refactor to use `toolkit.asbool()` to parse the config settings to have a consistent behavior with all other extensions. (ie, It wasn't parsing a `false` value)