### PR TITLE
Add ssl_verify option to callback_xloader_hook

### DIFF
--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -393,6 +393,7 @@ def callback_xloader_hook(result_url, api_key, job_dict):
         result = requests.post(
             result_url,
             data=json.dumps(job_dict, cls=DatetimeJsonEncoder),
+            verify=SSL_VERIFY,
             headers=headers)
     except requests.ConnectionError:
         return False


### PR DESCRIPTION
When working locally and using self signed certificates the POST request to `xloader_hook` fails to verify the certificate. This makes the job to never be updated to complete status after finishing.

I'm adding the `verify=SSL_VERIFY` parameter as we have in the `requests.get(...)` method.