### PR TITLE
Fix byte - str concat

### DIFF
--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -295,7 +295,7 @@ def _download_resource_data(resource, data, api_key, logger):
         line_count = 0
         m = hashlib.md5()
         for line in response.iter_lines(CHUNK_SIZE):
-            tmp_file.write(line + '\n')
+            tmp_file.write(line + b'\n')
             m.update(line)
             length += len(line)
             line_count += 1


### PR DESCRIPTION
When using Python 3 the DataTooBigError workflow fails with the following error:

```
Traceback (most recent call last):
File "/usr/local/lib/python3.8/dist-packages/ckanext/xloader/jobs.py", line 76, in xloader_data_into_datastore
xloader_data_into_datastore_(input, job_dict)
File "/usr/local/lib/python3.8/dist-packages/ckanext/xloader/jobs.py", line 156, in xloader_data_into_datastore_
tmp_file, file_hash = _download_resource_data(resource, data, api_key,
File "/usr/local/lib/python3.8/dist-packages/ckanext/xloader/jobs.py", line 298, in _download_resource_data
tmp_file.write(line + '\n')
TypeError: can't concat str to bytes
```

The error is because `response.iter_lines()` returns a byte object, so we need to prefix `\n`.