### PR TITLE
fix xloader exceptions

### DIFF
--- a/ckanext/xloader/plugin.py
+++ b/ckanext/xloader/plugin.py
@@ -39,7 +39,6 @@ class XLoaderFormats(object):
 class xloaderPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IConfigurer)
     plugins.implements(plugins.IConfigurable)
-    plugins.implements(plugins.IDomainObjectModification)
     plugins.implements(plugins.IResourceUrlChange)
     plugins.implements(plugins.IActions)
     plugins.implements(plugins.IAuthFunctions)
@@ -107,60 +106,71 @@ class xloaderPlugin(plugins.SingletonPlugin):
                                 'See ckanext-xloader\'s README.rst for more '
                                 'details.')
 
-    # IDomainObjectModification
     # IResourceUrlChange
 
-    def notify(self, entity, operation=None):
-        if isinstance(entity, model.Resource):
-            if (operation == model.domain_object.DomainObjectOperation.new or
-                    not operation):
-                # if operation is None, resource URL has been changed, as
-                # the notify function in IResourceUrlChange only takes
-                # 1 parameter
-                context = {'model': model, 'ignore_auth': True,
+    def notify(self, resource):
+        context = {
+            "model": model,
+            "ignore_auth": True,
+        }
+        resource_dict = toolkit.get_action("resource_show")(
+            context, {
+                "id": resource.id,
+            }
+        )
+        self._submit_to_xloader(resource_dict)
+
+    # IResourceController                
+
+    def after_create(self, context, resource_dict):
+
+        self._submit_to_xloader(resource_dict)
+
+    def _submit_to_xloader(self, resource_dict):
+        context = {'model': model, 'ignore_auth': True,
                            'defer_commit': True}
-                if not XLoaderFormats.is_it_an_xloader_format(entity.format):
-                    log.debug('Skipping xloading resource {r.id} because '
-                              'format "{r.format}" is not configured to be '
-                              'xloadered'
-                              .format(r=entity))
-                    return
-                if entity.url_type in ('datapusher', 'xloader'):
-                    log.debug('Skipping xloading resource {r.id} because '
-                              'url_type "{r.url_type}" means resource.url '
-                              'points to the datastore already, so loading '
-                              'would be circular.'.format(r=entity))
-                    return
+        if not XLoaderFormats.is_it_an_xloader_format(resource_dict["format"]):
+            log.debug('Skipping xloading resource {id} because '
+                        'format "{format}" is not configured to be '
+                        'xloadered'
+                        .format(**resource_dict))
+            return
+        if resource_dict["url_type"] in ('datapusher', 'xloader'):
+            log.debug('Skipping xloading resource {id} because '
+                        'url_type "{url_type}" means resource.url '
+                        'points to the datastore already, so loading '
+                        'would be circular.'.format(**resource_dict))
+            return
 
-                try:
-                    task = p.toolkit.get_action('task_status_show')(
-                        context, {
-                            'entity_id': entity.id,
-                            'task_type': 'xloader',
-                            'key': 'xloader'}
-                    )
-                #     if task.get('state') == 'pending':
-                #         # There already is a pending DataPusher submission,
-                #         # skip this one ...
-                #         log.debug(
-                #             'Skipping DataPusher submission for '
-                #             'resource {0}'.format(entity.id))
-                #         return
-                except p.toolkit.ObjectNotFound:
-                    pass
+        try:
+            task = p.toolkit.get_action('task_status_show')(
+                context, {
+                    'entity_id': resource_dict["id"],
+                    'task_type': 'xloader',
+                    'key': 'xloader'}
+            )
+        #     if task.get('state') == 'pending':
+        #         # There already is a pending DataPusher submission,
+        #         # skip this one ...
+        #         log.debug(
+        #             'Skipping DataPusher submission for '
+        #             'resource {0}'.format(entity.id))
+        #         return
+        except p.toolkit.ObjectNotFound:
+            pass
 
-                try:
-                    log.debug('Submitting resource {0} to be xloadered'
-                              .format(entity.id))
-                    p.toolkit.get_action('xloader_submit')(context, {
-                        'resource_id': entity.id,
-                        'ignore_hash': self.ignore_hash,
-                    })
-                except p.toolkit.ValidationError as e:
-                    # If xloader is offline, we want to catch error instead
-                    # of raising otherwise resource save will fail with 500
-                    log.critical(e)
-                    pass
+        try:
+            log.debug('Submitting resource {0} to be xloadered'
+                        .format(resource_dict["id"]))
+            p.toolkit.get_action('xloader_submit')(context, {
+                'resource_id': resource_dict["id"],
+                'ignore_hash': self.ignore_hash,
+            })
+        except p.toolkit.ValidationError as e:
+            # If xloader is offline, we want to catch error instead
+            # of raising otherwise resource save will fail with 500
+            log.critical(e)
+            pass
 
     # IActions
 


### PR DESCRIPTION
Enabling xloader causes an exception at the end of the dataset creation process, when submitting the resources.

![image](https://user-images.githubusercontent.com/72216462/131707006-1f3326be-130a-4ef1-9495-9816ad8078e0.png)

So .. i was following @amercader 's  work on [5137](https://github.com/ckan/ckan/pull/5173)