### PR TITLE
Fix xloader status timestamps

### DIFF
--- a/ckanext/xloader/action.py
+++ b/ckanext/xloader/action.py
@@ -342,9 +342,10 @@ def xloader_status(context, data_dict):
         db.init(config)
         job_detail = db.get_job(job_id)
 
-        for log in job_detail['logs']:
-            if 'timestamp' in log and isinstance(log['timestamp'], datetime.datetime):
-                log['timestamp'] = log['timestamp'].isoformat()
+        if job_detail.get('logs'):
+            for log in job_detail['logs']:
+                if 'timestamp' in log and isinstance(log['timestamp'], datetime.datetime):
+                    log['timestamp'] = log['timestamp'].isoformat()
     try:
         error = json.loads(task['error'])
     except ValueError:

--- a/ckanext/xloader/action.py
+++ b/ckanext/xloader/action.py
@@ -342,7 +342,7 @@ def xloader_status(context, data_dict):
         db.init(config)
         job_detail = db.get_job(job_id)
 
-        if job_detail.get('logs'):
+        if job_detail and job_detail.get('logs'):
             for log in job_detail['logs']:
                 if 'timestamp' in log and isinstance(log['timestamp'], datetime.datetime):
                     log['timestamp'] = log['timestamp'].isoformat()

--- a/ckanext/xloader/action.py
+++ b/ckanext/xloader/action.py
@@ -342,14 +342,9 @@ def xloader_status(context, data_dict):
         db.init(config)
         job_detail = db.get_job(job_id)
 
-        # timestamp is a date, so not sure why this code was there
-        # for log in job_detail['logs']:
-        #     if 'timestamp' in log:
-        #         date = time.strptime(
-        #             log['timestamp'], "%Y-%m-%dT%H:%M:%S.%f")
-        #         date = datetime.datetime.utcfromtimestamp(
-        #             time.mktime(date))
-        #         log['timestamp'] = date
+        for log in job_detail['logs']:
+            if 'timestamp' in log and isinstance(log['timestamp'], datetime.datetime):
+                log['timestamp'] = log['timestamp'].isoformat()
     try:
         error = json.loads(task['error'])
     except ValueError:

--- a/ckanext/xloader/job_exceptions.py
+++ b/ckanext/xloader/job_exceptions.py
@@ -1,3 +1,6 @@
+import six
+
+
 class DataTooBigError(Exception):
     pass
 
@@ -33,14 +36,15 @@ class HTTPError(JobError):
 
         """
         super(HTTPError, self).__init__(message)
+        self.message = message
         self.status_code = status_code
         self.request_url = request_url
         self.response = response
 
     def __str__(self):
-        return u'{} status={} url={} response={}'.format(
-            self.message, self.status_code, self.request_url, self.response) \
-            .encode('ascii', 'replace')
+        return six.text_type('{} status={} url={} response={}'.format(
+            self.message, self.status_code, self.request_url, self.response)
+            .encode('ascii', 'replace'))
 
 
 class LoaderError(JobError):

--- a/ckanext/xloader/tests/test_action.py
+++ b/ckanext/xloader/tests/test_action.py
@@ -80,3 +80,15 @@ class TestAction(object):
             key="xloader",
         )
         assert task_status["state"] == "complete"
+
+    def test_status(self):
+
+        # Triggere an xloader job
+        res = factories.Resource(format="CSV")
+
+        status = helpers.call_action(
+            "xloader_status",
+            resource_id=res["id"],
+        )
+
+        assert status['state'] == 'submitting'

--- a/ckanext/xloader/tests/test_action.py
+++ b/ckanext/xloader/tests/test_action.py
@@ -91,4 +91,4 @@ class TestAction(object):
             resource_id=res["id"],
         )
 
-        assert status['status'] == 'submitting'
+        assert status['status'] == 'pending'

--- a/ckanext/xloader/tests/test_action.py
+++ b/ckanext/xloader/tests/test_action.py
@@ -83,7 +83,7 @@ class TestAction(object):
 
     def test_status(self):
 
-        # Triggere an xloader job
+        # Trigger an xloader job
         res = factories.Resource(format="CSV")
 
         status = helpers.call_action(
@@ -91,4 +91,4 @@ class TestAction(object):
             resource_id=res["id"],
         )
 
-        assert status['state'] == 'submitting'
+        assert status['status'] == 'submitting'


### PR DESCRIPTION
Encode timestamps as strings on `xloader_status` call otherwise there is an error when trying to return the API JSON value.

This also includes a small fix to correctly report exceptions in stdout (40da6c6d8224907ad4798e0b4f97cdea64f65ce5)