### PR TITLE
support replacable CKAN hostname

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -265,6 +265,11 @@ Configuration:
     # to True.
     ckanext.xloader.ssl_verify = True
 
+    # The hostname of a CKAN server. The value should have the hostname.
+    # And you can add the port number on demand.
+    # You cannot put any protocols (http://, https://, etc) ahead of this value.
+    ckanext.xloader.ckan_host = ckan:5000
+
 ------------------------
 Developer installation
 ------------------------

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -245,6 +245,7 @@ def _download_resource_data(resource, data, api_key, logger):
     # check scheme
     url = resource.get('url')
 
+    # replace hostname in url
     if config.get('ckanext.xloader.ckan_host'):
         ckan_host = config.get('ckanext.xloader.ckan_host')
         url_parse_reseult = urlparse(url)

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -10,9 +10,8 @@ import datetime
 import traceback
 import sys
 import six
-from urllib.parse import urlparse, urlunparse
 
-from six.moves.urllib.parse import urlsplit
+from six.moves.urllib.parse import urlsplit, urlparse, urlunparse
 import requests
 from rq import get_current_job
 import sqlalchemy as sa

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -10,6 +10,7 @@ import datetime
 import traceback
 import sys
 import six
+from urllib.parse import urlparse, urlunparse
 
 from six.moves.urllib.parse import urlsplit
 import requests
@@ -243,6 +244,12 @@ def _download_resource_data(resource, data, api_key, logger):
     '''
     # check scheme
     url = resource.get('url')
+
+    if config.get('ckanext.xloader.ckan_host'):
+        ckan_host = config.get('ckanext.xloader.ckan_host')
+        url_parse_reseult = urlparse(url)
+        url = urlunparse(url_parse_reseult._replace(netloc=ckan_host))
+
     scheme = urlsplit(url).scheme
     if scheme not in ('http', 'https', 'ftp'):
         raise JobError(


### PR DESCRIPTION
When we run CKAN and XLoader on a Docker environment, we run only one process in a docker container as usual. Thus, we make two containers for that, and these containers have their IP addresses.

When XLoader calls the API endpoint `/api/3/action/resource_show` on CKAN, `url` value in the returned JSON object starts from `http://localhost` based on the congifuration `ckan.site_url`.

But `localhost` of the XLoader container doesn't point to the CKAN container, since these processes are running on another container. The hostname should be equal to the CKAN container name by default.

Therefore, the hostname of the `url` value should be replaceable via the configuration file.

That's why I added a new configuration `ckanext.xloader.ckan_host` to resolve the problem. This change should not affect the existing environment.