### PR TITLE
add future to requirements.txt

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,17 +61,14 @@ jobs:
     - name: Setup extension (CKAN >= 2.9)
       if: ${{ matrix.ckan-version != '2.7' && matrix.ckan-version != '2.8' }}
       run: |
-        pip install future
         ckan -c test.ini db init
     - name: Setup extension (CKAN 2.8)
       if: ${{ matrix.ckan-version == '2.8' }}
       run: |
-        pip install future
         paster --plugin=ckan db init -c test.ini
     - name: Setup extension (CKAN 2.7)
       if: ${{ matrix.ckan-version == '2.7' }}
       run: | 
-        pip install future
         psql -d postgresql://datastore_write:pass@postgres/datastore_test -f full_text_function.sql
         paster --plugin=ckan db init -c test.ini
     - name: Run tests

--- a/ckanext/xloader/action.py
+++ b/ckanext/xloader/action.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 
 from __future__ import absolute_import
-from builtins import str
+from six import text_type as str
 import logging
 import json
 import datetime

--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -1,7 +1,6 @@
 'Load a CSV into postgres'
 from __future__ import absolute_import
-from builtins import zip
-from builtins import str
+from six import text_type as str
 import os
 import os.path
 import tempfile

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-future>=0.18.2
 messytables==0.15.2
 Unidecode==1.0.22
 six>=1.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+future>=0.18.2
 messytables==0.15.2
 Unidecode==1.0.22
 six>=1.12.0


### PR DESCRIPTION
Python 3 support requires using `builtins` in commit https://github.com/open-data/ckanext-xloader/commit/8c43ceed879af9934dd843a36ab7c68d9a0535c8#diff-b0f564951458e386ad6106e20fa8938150638c260b1921aceba34dae89d04d58. Adding `future` to the requirements to avoid ImportError.