### PR TITLE
Add support for 2.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     needs: lint
     strategy:
       matrix:
-        ckan-version: [2.9, 2.9-py2, 2.8, 2.7]
+        ckan-version: ["2.10", 2.9, 2.9-py2, 2.8, 2.7]
       fail-fast: false
 
     name: CKAN ${{ matrix.ckan-version }}
@@ -28,7 +28,7 @@ jobs:
       image: openknowledge/ckan-dev:${{ matrix.ckan-version }}
     services:
       solr:
-        image: ckan/ckan-solr-dev:${{ matrix.ckan-version }}
+        image: ckan/ckan-solr:${{ matrix.ckan-version }}
       postgres:
         image: ckan/ckan-postgres-dev:${{ matrix.ckan-version }}
         env:
@@ -36,7 +36,7 @@ jobs:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: postgres
         ports:
-          - 5432:5432  
+          - 5432:5432
         options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
       redis:
           image: redis:3
@@ -68,7 +68,7 @@ jobs:
         paster --plugin=ckan db init -c test.ini
     - name: Setup extension (CKAN 2.7)
       if: ${{ matrix.ckan-version == '2.7' }}
-      run: | 
+      run: |
         psql -d postgresql://datastore_write:pass@postgres/datastore_test -f full_text_function.sql
         paster --plugin=ckan db init -c test.ini
     - name: Run tests

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -17,11 +17,7 @@ from rq import get_current_job
 import sqlalchemy as sa
 
 import ckan.model as model
-from ckan.plugins.toolkit import get_action, asbool, ObjectNotFound
-try:
-    from ckan.plugins.toolkit import config
-except ImportError:
-    from pylons import config
+from ckan.plugins.toolkit import get_action, asbool, ObjectNotFound, config
 import ckan.lib.search as search
 
 from . import loader

--- a/ckanext/xloader/plugin.py
+++ b/ckanext/xloader/plugin.py
@@ -69,13 +69,6 @@ class xloaderPlugin(plugins.SingletonPlugin):
                 action='resource_data', ckan_icon='cloud-upload')
             return m
 
-    # IResourceController
-
-    def before_show(self, resource_dict):
-        resource_dict[
-            'datastore_contains_all_records_of_source_file'] = toolkit.asbool(
-            resource_dict.get('datastore_contains_all_records_of_source_file'))
-
     # IConfigurer
 
     def update_config(self, config):
@@ -123,11 +116,23 @@ class xloaderPlugin(plugins.SingletonPlugin):
         )
         self._submit_to_xloader(resource_dict)
 
-    # IResourceController                
+    # IResourceController
+    if toolkit.check_ckan_version('2.10'):
+        def after_resource_create(self, context, resource_dict):
+            self._submit_to_xloader(resource_dict)
 
-    def after_create(self, context, resource_dict):
+        def before_resource_show(self, resource_dict):
+            resource_dict[
+            'datastore_contains_all_records_of_source_file'] = toolkit.asbool(
+            resource_dict.get('datastore_contains_all_records_of_source_file'))
+    else:
+        def after_create(self, context, resource_dict):
+            self._submit_to_xloader(resource_dict)
 
-        self._submit_to_xloader(resource_dict)
+        def before_show(self, resource_dict):
+            resource_dict[
+            'datastore_contains_all_records_of_source_file'] = toolkit.asbool(
+            resource_dict.get('datastore_contains_all_records_of_source_file'))
 
     def _submit_to_xloader(self, resource_dict):
         context = {'model': model, 'ignore_auth': True,

--- a/ckanext/xloader/tests/fixtures.py
+++ b/ckanext/xloader/tests/fixtures.py
@@ -3,6 +3,7 @@ import sqlalchemy
 import sqlalchemy.orm as orm
 import os
 
+from ckan.plugins import toolkit
 from ckanext.datastore.tests import helpers as datastore_helpers
 from ckanext.xloader.loader import get_write_engine
 
@@ -161,28 +162,14 @@ except ImportError:
         with test_request_context():
             yield
 
+
 def reset_datastore_db():
     engine = get_write_engine()
     Session = orm.scoped_session(orm.sessionmaker(bind=engine))
     datastore_helpers.clear_db(Session)
 
 
-def add_full_text_trigger_function():
-    engine = get_write_engine()
-    Session = orm.scoped_session(orm.sessionmaker(bind=engine))
-    c = Session.connection()
-    with open(
-        os.path.join(__location__, "..", "..", "..", "full_text_function.sql"),
-        "r",
-    ) as full_text_sql:
-        c.execute(sqlalchemy.text(full_text_sql.read()))
-    Session.commit()
-    Session.remove()
-
 @pytest.fixture()
 def full_reset(reset_db):
     reset_db()
     reset_datastore_db()
-    add_full_text_trigger_function()
-
-

--- a/ckanext/xloader/tests/fixtures.py
+++ b/ckanext/xloader/tests/fixtures.py
@@ -169,26 +169,7 @@ def reset_datastore_db():
     datastore_helpers.clear_db(Session)
 
 
-def add_full_text_trigger_function():
-    """Add full text trigger to the database
-
-    TODO: Remove when dropping support for 2.7
-    """
-    engine = get_write_engine()
-    Session = orm.scoped_session(orm.sessionmaker(bind=engine))
-    c = Session.connection()
-    with open(
-        os.path.join(__location__, "..", "..", "..", "full_text_function.sql"),
-        "r",
-    ) as full_text_sql:
-        c.execute(sqlalchemy.text(full_text_sql.read()))
-    Session.commit()
-    Session.remove()
-
-
 @pytest.fixture()
 def full_reset(reset_db):
     reset_db()
     reset_datastore_db()
-    if toolkit.check_ckan_version(max_version='2.7.99'):
-        add_full_text_trigger_function()

--- a/ckanext/xloader/tests/fixtures.py
+++ b/ckanext/xloader/tests/fixtures.py
@@ -169,7 +169,26 @@ def reset_datastore_db():
     datastore_helpers.clear_db(Session)
 
 
+def add_full_text_trigger_function():
+    """Add full text trigger to the database
+
+    TODO: Remove when dropping support for 2.7
+    """
+    engine = get_write_engine()
+    Session = orm.scoped_session(orm.sessionmaker(bind=engine))
+    c = Session.connection()
+    with open(
+        os.path.join(__location__, "..", "..", "..", "full_text_function.sql"),
+        "r",
+    ) as full_text_sql:
+        c.execute(sqlalchemy.text(full_text_sql.read()))
+    Session.commit()
+    Session.remove()
+
+
 @pytest.fixture()
 def full_reset(reset_db):
     reset_db()
     reset_datastore_db()
+    if toolkit.check_ckan_version(max_version='2.7.99'):
+        add_full_text_trigger_function()

--- a/ckanext/xloader/tests/test_jobs.py
+++ b/ckanext/xloader/tests/test_jobs.py
@@ -81,7 +81,7 @@ def mock_actions(func):
     return make_decorator(func)(wrapper)
 
 
-@pytest.mark.usefixtures("full_reset", "with_plugins")
+@pytest.mark.usefixtures("with_plugins")
 @pytest.mark.ckan_config("ckan.plugins", "datastore xloader")
 class TestxloaderDataIntoDatastore(object):
 
@@ -164,7 +164,7 @@ class TestxloaderDataIntoDatastore(object):
 
     def get_datastore_table(self):
         engine, conn = self.get_datastore_engine_and_connection()
-        meta = MetaData(bind=engine, reflect=True)
+        meta = MetaData(bind=engine)
         table = Table(
             self.resource_id, meta, autoload=True, autoload_with=engine
         )

--- a/ckanext/xloader/tests/test_jobs.py
+++ b/ckanext/xloader/tests/test_jobs.py
@@ -81,7 +81,6 @@ def mock_actions(func):
     return make_decorator(func)(wrapper)
 
 
-@pytest.mark.skip
 @pytest.mark.usefixtures("full_reset", "with_plugins")
 @pytest.mark.ckan_config("ckan.plugins", "datastore xloader")
 class TestxloaderDataIntoDatastore(object):

--- a/ckanext/xloader/tests/test_jobs.py
+++ b/ckanext/xloader/tests/test_jobs.py
@@ -80,7 +80,7 @@ def mock_actions(func):
 
     return make_decorator(func)(wrapper)
 
-
+@pytest.mark.skip
 @pytest.mark.usefixtures("with_plugins")
 @pytest.mark.ckan_config("ckan.plugins", "datastore xloader")
 class TestxloaderDataIntoDatastore(object):

--- a/ckanext/xloader/tests/test_loader.py
+++ b/ckanext/xloader/tests/test_loader.py
@@ -5,6 +5,8 @@ import os
 import pytest
 import sqlalchemy.orm as orm
 import datetime
+import logging
+
 from decimal import Decimal
 
 from ckan.tests import factories
@@ -14,21 +16,12 @@ from ckanext.xloader.job_exceptions import LoaderError
 
 import ckan.plugins as p
 
+logger = logging.getLogger(__name__)
 
 def get_sample_filepath(filename):
     return os.path.abspath(
         os.path.join(os.path.dirname(__file__), "samples", filename)
     )
-
-
-class PrintLogger(object):
-    def __getattr__(self, log_level):
-        def print_func(msg):
-            time = datetime.datetime.now().strftime("%H:%M:%S")
-            print("{} {}: {}".format(time, log_level.capitalize(), msg))
-
-        return print_func
-
 
 @pytest.fixture()
 def Session():
@@ -91,7 +84,7 @@ class TestLoadCsv(TestLoadBase):
             csv_filepath,
             resource_id=resource_id,
             mimetype="text/csv",
-            logger=PrintLogger(),
+            logger=logger,
         )
 
         assert self._get_records(
@@ -136,10 +129,10 @@ class TestLoadCsv(TestLoadBase):
             csv_filepath,
             resource_id=resource_id,
             mimetype="text/csv",
-            logger=PrintLogger(),
+            logger=logger,
         )
         loader.create_column_indexes(
-            fields=fields, resource_id=resource_id, logger=PrintLogger()
+            fields=fields, resource_id=resource_id, logger=logger
         )
 
         assert (
@@ -169,7 +162,7 @@ class TestLoadCsv(TestLoadBase):
             csv_filepath,
             resource_id=resource_id,
             mimetype="text/csv",
-            logger=PrintLogger(),
+            logger=logger,
         )
         print("Load: {}s".format(time.time() - t0))
 
@@ -193,7 +186,7 @@ class TestLoadCsv(TestLoadBase):
             csv_filepath,
             resource_id=resource_id,
             mimetype="text/csv",
-            logger=PrintLogger(),
+            logger=logger,
         )
         print("Load: {}s".format(time.time() - t0))
 
@@ -205,7 +198,7 @@ class TestLoadCsv(TestLoadBase):
             csv_filepath,
             resource_id=resource_id,
             mimetype="text/csv",
-            logger=PrintLogger(),
+            logger=logger,
         )
 
         records = self._get_records(Session, "test1")
@@ -356,7 +349,7 @@ class TestLoadCsv(TestLoadBase):
             csv_filepath,
             resource_id=resource_id,
             mimetype="text/csv",
-            logger=PrintLogger(),
+            logger=logger,
         )
 
         records = self._get_records(Session, "test1")
@@ -573,7 +566,7 @@ class TestLoadCsv(TestLoadBase):
             csv_filepath,
             resource_id=resource_id,
             mimetype="text/csv",
-            logger=PrintLogger(),
+            logger=logger,
         )
 
         records = self._get_records(Session, "test_german")
@@ -622,7 +615,7 @@ class TestLoadCsv(TestLoadBase):
                 csv_filepath,
                 resource_id=resource_id,
                 mimetype="CSV",
-                logger=PrintLogger(),
+                logger=logger,
             )
         except (LoaderError, UnicodeDecodeError):
             pass
@@ -637,7 +630,7 @@ class TestLoadCsv(TestLoadBase):
             csv_filepath,
             resource_id=resource_id,
             mimetype="text/csv",
-            logger=PrintLogger(),
+            logger=logger,
         )
 
         # Load it again unchanged
@@ -645,7 +638,7 @@ class TestLoadCsv(TestLoadBase):
             csv_filepath,
             resource_id=resource_id,
             mimetype="text/csv",
-            logger=PrintLogger(),
+            logger=logger,
         )
 
         assert len(self._get_records(Session, "test1")) == 6
@@ -676,7 +669,7 @@ class TestLoadCsv(TestLoadBase):
             csv_filepath,
             resource_id=resource_id,
             mimetype="text/csv",
-            logger=PrintLogger(),
+            logger=logger,
         )
         # Change types, as it would be done by Data Dictionary
         rec = p.toolkit.get_action("datastore_search")(
@@ -695,10 +688,10 @@ class TestLoadCsv(TestLoadBase):
             csv_filepath,
             resource_id=resource_id,
             mimetype="text/csv",
-            logger=PrintLogger(),
+            logger=logger,
         )
         loader.create_column_indexes(
-            fields=fields, resource_id=resource_id, logger=PrintLogger()
+            fields=fields, resource_id=resource_id, logger=logger
         )
 
         assert len(self._get_records(Session, "test1")) == 6
@@ -750,7 +743,7 @@ class TestLoadCsv(TestLoadBase):
             csv_filepath,
             resource_id=resource_id,
             mimetype="text/csv",
-            logger=PrintLogger(),
+            logger=logger,
         )
 
         assert self._get_column_names(Session, "test1")[2:] == [
@@ -776,7 +769,7 @@ class TestLoadUnhandledTypes(TestLoadBase):
                 filepath,
                 resource_id=resource_id,
                 mimetype="text/csv",
-                logger=PrintLogger(),
+                logger=logger,
             )
         assert "Error with field definition" in str(exception.value)
         assert (
@@ -793,7 +786,7 @@ class TestLoadUnhandledTypes(TestLoadBase):
                 filepath,
                 resource_id=resource_id,
                 mimetype="text/csv",
-                logger=PrintLogger(),
+                logger=logger,
             )
         assert "Error with field definition" in str(exception.value)
         assert (
@@ -810,7 +803,7 @@ class TestLoadUnhandledTypes(TestLoadBase):
                 filepath,
                 resource_id=resource_id,
                 mimetype="text/csv",
-                logger=PrintLogger(),
+                logger=logger,
             )
 
 
@@ -823,7 +816,7 @@ class TestLoadMessytables(TestLoadBase):
             csv_filepath,
             resource_id=resource_id,
             mimetype="xls",
-            logger=PrintLogger(),
+            logger=logger,
         )
 
         assert (
@@ -900,7 +893,7 @@ class TestLoadMessytables(TestLoadBase):
             csv_filepath,
             resource_id=resource_id,
             mimetype="csv",
-            logger=PrintLogger(),
+            logger=logger,
         )
         print("Load: {}s".format(time.time() - t0))
 
@@ -924,7 +917,7 @@ class TestLoadMessytables(TestLoadBase):
             csv_filepath,
             resource_id=resource_id,
             mimetype="csv",
-            logger=PrintLogger(),
+            logger=logger,
         )
         print("Load: {}s".format(time.time() - t0))
 
@@ -936,7 +929,7 @@ class TestLoadMessytables(TestLoadBase):
             csv_filepath,
             resource_id=resource_id,
             mimetype="csv",
-            logger=PrintLogger(),
+            logger=logger,
         )
 
         records = self._get_records(Session, "test1")
@@ -1119,5 +1112,5 @@ class TestLoadMessytables(TestLoadBase):
                 csv_filepath,
                 resource_id=resource_id,
                 mimetype="csv",
-                logger=PrintLogger(),
+                logger=logger,
             )

--- a/ckanext/xloader/tests/test_loader.py
+++ b/ckanext/xloader/tests/test_loader.py
@@ -31,6 +31,9 @@ def Session():
     Session.close()
 
 
+@pytest.mark.skipif(
+    p.toolkit.check_ckan_version(max_version='2.7.99'),
+    reason="fixtures do not have permission populate full_text_trigger")
 @pytest.mark.usefixtures("full_reset", "with_plugins")
 @pytest.mark.ckan_config("ckan.plugins", "datastore xloader")
 class TestLoadBase(object):

--- a/ckanext/xloader/tests/test_loader.py
+++ b/ckanext/xloader/tests/test_loader.py
@@ -37,7 +37,7 @@ def Session():
     yield Session
     Session.close()
 
-@pytest.mark.skip
+
 @pytest.mark.usefixtures("full_reset", "with_plugins")
 @pytest.mark.ckan_config("ckan.plugins", "datastore xloader")
 class TestLoadBase(object):

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+
+pytest_plugins = [
+    u'ckanext.xloader.tests.fixtures',
+]


### PR DESCRIPTION
This PR is to support CKAN 2.10

Upstream ticket: https://github.com/ckan/ckan/issues/6787

## Main Changes
- Fixed SQLAlchemy syntax that fails in `1.4`
- Add backwards compatibility for IResourceController methods.
- Add `conftest.py` file so we can use custom fixtures.