### PR TITLE
Raise loadererror when the delimiter cannot be detected

### DIFF
--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -80,6 +80,8 @@ def load_csv(csv_filepath, resource_id, mimetype='text/csv', logger=None):
     except csv.Error:
         logger.warning('Could not determine delimiter from file, use default ","')
         delimiter = ','
+    except UnicodeDecodeError:
+        raise LoaderError('Could not detect delimiter in this file')
 
     # Setup the converters that run when you iterate over the row_set.
     # With pgloader only the headers will be iterated over.


### PR DESCRIPTION
In case messytables by default is off and one supplies a non-CSV file, the delimiter detection fails with a UnicodeDecodeError as it tries to parse the binary data (I presume). By catching that error and raising a LoadError instead, subsequent code picks it up and uses messytables as a fallback option.