### PR TITLE
Add root path to callback_url

### DIFF
--- a/ckanext/xloader/action.py
+++ b/ckanext/xloader/action.py
@@ -66,7 +66,12 @@ def xloader_submit(context, data_dict):
         return False
 
     site_url = config['ckan.site_url']
-    callback_url = site_url + '/api/3/action/xloader_hook'
+    callback_url = p.toolkit.url_for(
+        "api.action",
+        ver=3,
+        logic_function="xloader_hook",
+        qualified=True
+    )
 
     site_user = p.toolkit.get_action('get_site_user')({'ignore_auth': True}, {})
 


### PR DESCRIPTION
At the moment service makes a request to a `ckan.site_url` when a job finishes. If the CKAN app is mounted using `ckan.root_path`, the job is never marked as finished. 
It doesn't hurt much but creates some inconveniences. For example, default previews are not created.