### PR TITLE
Do not pin ckantoolkit version

### DIFF
--- a/pip-requirements.txt
+++ b/pip-requirements.txt
@@ -1,4 +1,4 @@
-ckantoolkit==0.0.4
+ckantoolkit
 pika>=1.1.0
 pyOpenSSL==18.0.0
 redis


### PR DESCRIPTION
`ckantoolkit` is backward-compatible, so it's safe to use newer versions. 
In addition, v0.0.4 didn't have a `unicode_safe` validator, thus `ckanext-xloader` with the pinned version of `ckantoolkit` may break environments after migration to CKAN v2.10.