### PR TITLE
Cleanup from QGOV fork

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -4,6 +4,7 @@
 exclude =
     ckan
     scripts
+    .git
 
 # Extended output format.
 format = pylint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,3 +1,4 @@
+---
 name: Tests
 on: [push, pull_request]
 jobs:
@@ -68,7 +69,7 @@ jobs:
     - name: Setup extension (CKAN 2.7)
       if: ${{ matrix.ckan-version == '2.7' }}
       run: |
-        psql -d postgresql://datastore_write:pass@postgres/datastore_test -f full_text_function.sql
+        psql -d "postgresql://datastore_write:pass@postgres/datastore_test" -f full_text_function.sql
         paster --plugin=ckan db init -c test.ini
     - name: Run tests
       run: pytest --ckan-ini=test.ini --cov=ckanext.xloader --disable-warnings ckanext/xloader/tests

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,8 @@ docs/_build/
 # editors
 .vscode
 
+ckan
+.rdp
+.noseids
+subdir/
+dump.rdb

--- a/README.rst
+++ b/README.rst
@@ -171,7 +171,7 @@ To install XLoader:
    Ensure ``datastore`` is also listed, to enable CKAN DataStore.
 
 6. Starting CKAN 2.10 you will need to set an API Token to be able to
-   exeute jobs against the server::
+   execute jobs against the server::
 
      ckanext.xloader.api_token = <your-CKAN-generated-API-Token>
 

--- a/ckanext/xloader/action.py
+++ b/ckanext/xloader/action.py
@@ -14,10 +14,7 @@ from six import text_type as str
 
 import ckanext.xloader.schema
 
-from . import interfaces as xloader_interfaces
-from . import jobs
-from . import db
-from . import utils
+from . import interfaces as xloader_interfaces, jobs, db, utils
 
 enqueue_job = p.toolkit.enqueue_job
 get_queue = rq_jobs.get_queue
@@ -287,8 +284,8 @@ def xloader_hook(context, data_dict):
                     resource_dict['last_modified'])
                 task_created_datetime = parse_date(metadata['task_created'])
                 if last_modified_datetime > task_created_datetime:
-                    log.debug('Uploaded file more recent: {0} > {1}'.format(
-                        last_modified_datetime, task_created_datetime))
+                    log.debug('Uploaded file more recent: %s > %s',
+                              last_modified_datetime, task_created_datetime)
                     resubmit = True
             except ValueError:
                 pass

--- a/ckanext/xloader/action.py
+++ b/ckanext/xloader/action.py
@@ -318,6 +318,8 @@ def xloader_status(context, data_dict):
 
     p.toolkit.check_access('xloader_status', context, data_dict)
 
+    if 'id' in data_dict:
+        data_dict['resource_id'] = data_dict['id']
     res_id = _get_or_bust(data_dict, 'resource_id')
 
     task = p.toolkit.get_action('task_status_show')(context, {

--- a/ckanext/xloader/command.py
+++ b/ckanext/xloader/command.py
@@ -53,6 +53,7 @@ class XloaderCmd:
             self._submit_package(p_id, user, indent=2)
 
     def _submit_package(self, pkg_id, user=None, indent=0):
+        indentation = ' ' * indent
         if not user:
             user = tk.get_action('get_site_user')(
                 {'ignore_auth': True}, {})
@@ -63,10 +64,10 @@ class XloaderCmd:
                 {'id': pkg_id.strip()})
         except Exception as e:
             print(e)
-            print(' ' * indent + 'Dataset "{}" was not found'.format(pkg_id))
+            print(indentation + 'Dataset "{}" was not found'.format(pkg_id))
             sys.exit(1)
 
-        print(' ' * indent + 'Processing dataset {} with {} resources'.format(
+        print(indentation + 'Processing dataset {} with {} resources'.format(
               pkg['name'], len(pkg['resources'])))
         for resource in pkg['resources']:
             try:
@@ -75,45 +76,46 @@ class XloaderCmd:
             except Exception as e:
                 self.error_occured = True
                 print(e)
-                print(' ' * indent + 'ERROR submitting resource "{}" '.format(
+                print(indentation + 'ERROR submitting resource "{}" '.format(
                     resource['id']))
                 continue
 
     def _submit_resource(self, resource, user, indent=0):
         '''resource: resource dictionary
         '''
+        indentation = ' ' * indent
         # import here, so that that loggers are setup
         from ckanext.xloader.plugin import XLoaderFormats
 
         if not XLoaderFormats.is_it_an_xloader_format(resource['format']):
-            print(' ' * indent +
-                  'Skipping resource {r[id]} because format "{r[format]}" is '
+            print(indentation
+                  + 'Skipping resource {r[id]} because format "{r[format]}" is '
                   'not configured to be xloadered'.format(r=resource))
             return
         if resource['url_type'] in ('datapusher', 'xloader'):
-            print(' ' * indent +
-                  'Skipping resource {r[id]} because url_type "{r[url_type]}" '
+            print(indentation
+                  + 'Skipping resource {r[id]} because url_type "{r[url_type]}" '
                   'means resource.url points to the datastore '
                   'already, so loading would be circular.'.format(
-                    r=resource))
+                      r=resource))
             return
         dataset_ref = resource.get('package_name', resource['package_id'])
         print('{indent}Submitting /dataset/{dataset}/resource/{r[id]}\n'
               '{indent}           url={r[url]}\n'
               '{indent}           format={r[format]}'
-              .format(dataset=dataset_ref, r=resource, indent=' ' * indent))
+              .format(dataset=dataset_ref, r=resource, indent=indentation))
         data_dict = {
             'resource_id': resource['id'],
             'ignore_hash': True,
         }
         if self.dry_run:
-            print(' ' * indent + '(not submitted - dry-run)')
+            print(indentation + '(not submitted - dry-run)')
             return
         success = tk.get_action('xloader_submit')({'user': user['name']}, data_dict)
         if success:
-            print(' ' * indent + '...ok')
+            print(indentation + '...ok')
         else:
-            print(' ' * indent + 'ERROR submitting resource')
+            print(indentation + 'ERROR submitting resource')
             self.error_occured = True
 
     def print_status(self):
@@ -130,8 +132,8 @@ class XloaderCmd:
             job_metadata = job_params['metadata']
             print('{id} Enqueued={enqueued:%Y-%m-%d %H:%M} res_id={res_id} '
                   'url={url}'.format(
-                    id=job._id,
-                    enqueued=job.enqueued_at,
-                    res_id=job_metadata['resource_id'],
-                    url=job_metadata['original_url'],
+                      id=job._id,
+                      enqueued=job.enqueued_at,
+                      res_id=job_metadata['resource_id'],
+                      url=job_metadata['original_url'],
                   ))

--- a/ckanext/xloader/db.py
+++ b/ckanext/xloader/db.py
@@ -198,7 +198,7 @@ def add_pending_job(job_id, job_type, api_key,
             job_id=job_id,
             job_type=job_type,
             status='pending',
-            requested_timestamp=datetime.datetime.now(),
+            requested_timestamp=datetime.datetime.utcnow(),
             sent_data=data,
             result_url=result_url,
             api_key=api_key))
@@ -325,7 +325,7 @@ def mark_job_as_completed(job_id, data=None):
     update_dict = {
         "status": "complete",
         "data": json.dumps(data),
-        "finished_timestamp": datetime.datetime.now(),
+        "finished_timestamp": datetime.datetime.utcnow(),
     }
     _update_job(job_id, update_dict)
 
@@ -340,7 +340,7 @@ def mark_job_as_missed(job_id):
     update_dict = {
         "status": "error",
         "error": "Job delayed too long, service full",
-        "finished_timestamp": datetime.datetime.now(),
+        "finished_timestamp": datetime.datetime.utcnow(),
     }
     _update_job(job_id, update_dict)
 
@@ -359,7 +359,7 @@ def mark_job_as_errored(job_id, error_object):
     update_dict = {
         "status": "error",
         "error": error_object,
-        "finished_timestamp": datetime.datetime.now(),
+        "finished_timestamp": datetime.datetime.utcnow(),
     }
     _update_job(job_id, update_dict)
 

--- a/ckanext/xloader/job_exceptions.py
+++ b/ckanext/xloader/job_exceptions.py
@@ -1,4 +1,6 @@
-import six
+# encoding: utf-8
+
+from six import text_type as str
 
 
 class DataTooBigError(Exception):
@@ -42,7 +44,7 @@ class HTTPError(JobError):
         self.response = response
 
     def __str__(self):
-        return six.text_type('{} status={} url={} response={}'.format(
+        return str('{} status={} url={} response={}'.format(
             self.message, self.status_code, self.request_url, self.response)
             .encode('ascii', 'replace'))
 

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -335,7 +335,7 @@ def _download_resource_data(resource, data, api_key, logger):
 def get_response(url, headers):
     def get_url():
         kwargs = {'headers': headers, 'timeout': DOWNLOAD_TIMEOUT,
-                  'verify': SSL_VERIFY, 'stream': True} # just gets the headers for now
+                  'verify': SSL_VERIFY, 'stream': True}  # just gets the headers for now
         if 'ckan.download_proxy' in config:
             proxy = config.get('ckan.download_proxy')
             kwargs['proxies'] = {'http': proxy, 'https': proxy}

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -586,7 +586,7 @@ class StoringHandler(logging.Handler):
 
             conn.execute(db.LOGS_TABLE.insert().values(
                 job_id=self.task_id,
-                timestamp=datetime.datetime.now(),
+                timestamp=datetime.datetime.utcnow(),
                 message=message,
                 level=level,
                 module=module,

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -313,7 +313,7 @@ def _download_resource_data(resource, data, api_key, logger):
             "the data file", status_code=error.response.status_code,
             request_url=url, response=error)
     except requests.exceptions.Timeout:
-        logger.warning('URL time out after {0}s'.format(DOWNLOAD_TIMEOUT))
+        logger.warning('URL time out after %ss', DOWNLOAD_TIMEOUT)
         raise JobError('Connection timed out after {}s'.format(
                        DOWNLOAD_TIMEOUT))
     except requests.exceptions.RequestException as e:

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -9,7 +9,7 @@ import json
 import datetime
 import traceback
 import sys
-import six
+from six import text_type as str
 
 from six.moves.urllib.parse import urlsplit
 import requests
@@ -579,10 +579,10 @@ class StoringHandler(logging.Handler):
         try:
             # Turn strings into unicode to stop SQLAlchemy
             # "Unicode type received non-unicode bind param value" warnings.
-            message = six.text_type(record.getMessage())
-            level = six.text_type(record.levelname)
-            module = six.text_type(record.module)
-            funcName = six.text_type(record.funcName)
+            message = str(record.getMessage())
+            level = str(record.levelname)
+            module = str(record.module)
+            funcName = str(record.funcName)
 
             conn.execute(db.LOGS_TABLE.insert().values(
                 job_id=self.task_id,

--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -8,6 +8,7 @@ import itertools
 import csv
 
 import six
+from six.moves import zip
 import psycopg2
 import messytables
 from unidecode import unidecode

--- a/ckanext/xloader/plugin.py
+++ b/ckanext/xloader/plugin.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 import logging
 
 from ckan.plugins.toolkit import config

--- a/ckanext/xloader/plugin.py
+++ b/ckanext/xloader/plugin.py
@@ -177,7 +177,7 @@ class xloaderPlugin(plugins.SingletonPlugin):
 
         try:
             log.debug(
-                "Submitting resource {0} to be xloadered".format(resource_dict["id"])
+                "Submitting resource %s to be xloadered", resource_dict["id"]
             )
             toolkit.get_action("xloader_submit")(
                 context,

--- a/ckanext/xloader/schema.py
+++ b/ckanext/xloader/schema.py
@@ -1,3 +1,7 @@
+# encoding: utf-8
+
+from six import text_type as str
+
 import ckan.plugins as p
 import ckanext.datastore.logic.schema as dsschema
 

--- a/ckanext/xloader/tests/fixtures.py
+++ b/ckanext/xloader/tests/fixtures.py
@@ -13,7 +13,6 @@ __location__ = os.path.realpath(
 
 try:
     from ckan.tests.pytest_ckan.fixtures import *
-
 except ImportError:
     import pytest
 

--- a/ckanext/xloader/tests/fixtures.py
+++ b/ckanext/xloader/tests/fixtures.py
@@ -3,7 +3,6 @@ import sqlalchemy
 import sqlalchemy.orm as orm
 import os
 
-from ckan.plugins import toolkit
 from ckanext.datastore.tests import helpers as datastore_helpers
 from ckanext.xloader.loader import get_write_engine
 

--- a/ckanext/xloader/tests/test_jobs.py
+++ b/ckanext/xloader/tests/test_jobs.py
@@ -5,7 +5,11 @@ import random
 import datetime
 import time
 import six
-from collections import OrderedDict  # from python 2.7
+
+try:
+    from collections import OrderedDict  # from python 2.7
+except ImportError:
+    from sqlalchemy.util import OrderedDict
 import pytest
 
 from nose.tools import make_decorator

--- a/ckanext/xloader/tests/test_jobs.py
+++ b/ckanext/xloader/tests/test_jobs.py
@@ -80,6 +80,7 @@ def mock_actions(func):
 
     return make_decorator(func)(wrapper)
 
+
 @pytest.mark.skip
 @pytest.mark.usefixtures("with_plugins")
 @pytest.mark.ckan_config("ckan.plugins", "datastore xloader")

--- a/ckanext/xloader/tests/test_jobs.py
+++ b/ckanext/xloader/tests/test_jobs.py
@@ -573,6 +573,53 @@ class TestxloaderDataIntoDatastore(object):
 
     @mock_actions
     @responses.activate
+    def test_invalid_byte_sequence(self):
+        self.register_urls(filename='go-realtime.xlsx')
+        # This xlsx throws an Postgres error on INSERT because of
+        # 'invalid byte sequence for encoding "UTF8": 0x00' which causes
+        # the COPY to throw a psycopg2.DataError and umlauts in the file can
+        # cause problems for logging the error. We need to check that
+        # it correctly reverts to using messytables to load it
+        data = {
+            'api_key': self.api_key,
+            'job_type': 'xloader_to_datastore',
+            'result_url': self.callback_url,
+            'metadata': {
+                'ckan_url': 'http://%s/' % self.host,
+                'resource_id': self.resource_id
+            }
+        }
+        job_id = "test{}".format(random.randint(0, 1e5))
+
+        with mock.patch('ckanext.xloader.jobs.set_datastore_active_flag'):
+            # in tests we call jobs directly, rather than use rq, so mock
+            # get_current_job()
+            with mock.patch(
+                "ckanext.xloader.jobs.get_current_job",
+                return_value=mock.Mock(id=job_id),
+            ):
+                result = jobs.xloader_data_into_datastore(data)
+        assert result is None, jobs_db.get_job(job_id)["error"]["message"]
+
+        # Check it said it was successful
+        assert responses.calls[-1].request.url == \
+            'http://www.ckan.org/api/3/action/xloader_hook'
+        job_dict = json.loads(responses.calls[-1].request.body)
+        assert job_dict['status'] == u'complete', job_dict
+        assert job_dict == \
+            {u'metadata': {u'ckan_url': u'http://www.ckan.org/',
+                           u'resource_id': u'foo-bar-42'},
+             u'status': u'complete'}
+
+        logs = self.get_load_logs(job_id)
+        logs.assert_no_errors()
+
+        job = jobs_db.get_job(job_id)
+        assert job['status'] == u'complete'
+        assert job['error'] is None
+
+    @mock_actions
+    @responses.activate
     def test_first_request_is_202_pending_response(self):
         # when you first get the CSV it returns this 202 response, which is
         # what this server does: https://data-cdfw.opendata.arcgis.com/datasets

--- a/ckanext/xloader/tests/test_loader.py
+++ b/ckanext/xloader/tests/test_loader.py
@@ -6,6 +6,7 @@ import pytest
 import sqlalchemy.orm as orm
 import datetime
 import logging
+from six import text_type as str
 
 from decimal import Decimal
 

--- a/ckanext/xloader/tests/test_plugin.py
+++ b/ckanext/xloader/tests/test_plugin.py
@@ -1,6 +1,9 @@
+# encoding: utf-8
+
 import datetime
 import pytest
 import mock
+from six import text_type as str
 from ckan.tests import helpers, factories
 from ckan.logic import _actions
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # http://packaging.python.org/en/latest/tutorial.html#version
-    version='0.9.0',
+    version='0.11.0',
 
     description='Express Loader - quickly load data into CKAN DataStore''',
     long_description=long_description,


### PR DESCRIPTION
- Fix typos
- Use 'six' for greater compatibility/consistency
- Use parameterised logging instead of formatting up-front
- Add a test for byte decoding problems