### PR TITLE
Fixed date parsing while fetching entries for task_status

### DIFF
--- a/ckanext/xloader/action.py
+++ b/ckanext/xloader/action.py
@@ -99,20 +99,7 @@ def xloader_submit(context, data_dict):
                 for job in get_queue().get_jobs()
                 if 'xloader_to_datastore' in str(job)  # filter out test_job etc
             ]
-
-            # Parse date format from the following valid dates
-            date_formats = ['%Y-%m-%dT%H:%M:%S', '%Y-%m-%dT%H:%M:%S.%f']
-            updated = None
-            for format in date_formats:
-                try:
-                    updated = datetime.datetime.strptime(
-                        existing_task['last_updated'], format)
-                except ValueError:
-                    pass
-            if not updated:
-                log.exception('Invalid last_updated date for entity_id=%s', res_id)
-                return False
-
+            updated = parse_date(existing_task['last_updated'])
             time_since_last_updated = datetime.datetime.utcnow() - updated
             if (res_id not in queued_res_ids
                     and time_since_last_updated > assume_task_stillborn_after):

--- a/ckanext/xloader/action.py
+++ b/ckanext/xloader/action.py
@@ -10,6 +10,7 @@ import ckan.lib.navl.dictization_functions
 from ckan.logic import side_effect_free
 import ckan.plugins as p
 from dateutil.parser import parse as parse_date
+from dateutil.parser import isoparse as parse_iso_date
 from six import text_type as str
 
 import ckanext.xloader.schema
@@ -99,7 +100,7 @@ def xloader_submit(context, data_dict):
                 for job in get_queue().get_jobs()
                 if 'xloader_to_datastore' in str(job)  # filter out test_job etc
             ]
-            updated = parse_date(existing_task['last_updated'])
+            updated = parse_iso_date(existing_task['last_updated'])
             time_since_last_updated = datetime.datetime.utcnow() - updated
             if (res_id not in queued_res_ids
                     and time_since_last_updated > assume_task_stillborn_after):


### PR DESCRIPTION
Found issues while parsing the `last_updated` date from the `task_status` table.

- The fix includes parsing the `last_updated` date without microseconds as ckan APIs are not promising the date will always include microseconds.

Error logs
```
Traceback (most recent call last):
  File "/usr/lib/ckan/odp/src/ckanext-datastore-refresh/ckanext/datastore_refresh/cli.py", line 56, in dataset
    _submit_resource(pkg_dict, res, context)
  File "/usr/lib/ckan/odp/src/ckanext-datastore-refresh/ckanext/datastore_refresh/cli.py", line 117, in _submit_resource
    success = tk.get_action("xloader_submit")(context, data_dict)
  File "/usr/lib/ckan/odp/src/ckan/ckan/logic/__init__.py", line 504, in wrapped
    result = _action(context, data_dict, **kw)
  File "/usr/lib/ckan/odp/src/ckanext-xloader/ckanext/xloader/action.py", line 105, in xloader_submit
    updated = datetime.datetime.strptime(
  File "/opt/pyenv/versions/3.8.9/lib/python3.8/_strptime.py", line 568, in _strptime_datetime
    tt, fraction, gmtoff_fraction = _strptime(data_string, format)
  File "/opt/pyenv/versions/3.8.9/lib/python3.8/_strptime.py", line 349, in _strptime
    raise ValueError("time data %r does not match format %r" %
ValueError: time data '2022-06-30T19:48:06' does not match format '%Y-%m-%dT%H:%M:%S.%f'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/ckan/odp/bin/ckan", line 33, in <module>
    sys.exit(load_entry_point('ckan', 'console_scripts', 'ckan')())
  File "/usr/lib/ckan/odp/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/ckan/odp/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/usr/lib/ckan/odp/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/ckan/odp/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/lib/ckan/odp/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/ckan/odp/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/ckan/odp/src/ckanext-datastore-refresh/ckanext/datastore_refresh/cli.py", line 58, in dataset
    click.secho(e, fg="red")
  File "/usr/lib/ckan/odp/lib/python3.8/site-packages/click/termui.py", line 547, in secho
    message = style(message, **styles)
  File "/usr/lib/ckan/odp/lib/python3.8/site-packages/click/termui.py", line 519, in style
    return "".join(bits)
TypeError: sequence item 1: expected str instance, ValueError found
```