### PR TITLE
Use IDomainObjectModification Implementation

### DIFF
--- a/ckanext/xloader/plugin.py
+++ b/ckanext/xloader/plugin.py
@@ -5,6 +5,9 @@ import logging
 from ckan import plugins
 from ckan.plugins import toolkit
 
+from ckan.model.domain_object import DomainObjectOperation
+from ckan.model.resource import Resource
+
 from . import action, auth, helpers as xloader_helpers, utils
 from .loader import fulltext_function_exists, get_write_engine
 
@@ -53,7 +56,7 @@ class XLoaderFormats(object):
 class xloaderPlugin(plugins.SingletonPlugin):
     plugins.implements(plugins.IConfigurer)
     plugins.implements(plugins.IConfigurable)
-    plugins.implements(plugins.IResourceUrlChange)
+    plugins.implements(plugins.IDomainObjectModification)
     plugins.implements(plugins.IActions)
     plugins.implements(plugins.IAuthFunctions)
     plugins.implements(plugins.ITemplateHelpers)
@@ -94,16 +97,25 @@ class xloaderPlugin(plugins.SingletonPlugin):
                     )
                 )
 
-    # IResourceUrlChange
+    # IDomainObjectModification
 
-    def notify(self, resource):
+    def notify(self, entity, operation):
+        # type: (ckan.model.Package|ckan.model.Resource, DomainObjectOperation) -> None
+        """
+        Runs before_commit to database for Packages and Resources.
+        We only want to check for changed Resources for this.
+        We want to check if values have changed, namely the url.
+        See: ckan/model/modification.py.DomainObjectModificationExtension
+        """
+        if operation != DomainObjectOperation.changed or not isinstance(entity, Resource):
+            return
         context = {
             "ignore_auth": True,
         }
         resource_dict = toolkit.get_action("resource_show")(
             context,
             {
-                "id": resource.id,
+                "id": entity.id,
             },
         )
         self._submit_to_xloader(resource_dict)

--- a/ckanext/xloader/plugin.py
+++ b/ckanext/xloader/plugin.py
@@ -107,7 +107,9 @@ class xloaderPlugin(plugins.SingletonPlugin):
         We want to check if values have changed, namely the url.
         See: ckan/model/modification.py.DomainObjectModificationExtension
         """
-        if operation != DomainObjectOperation.changed or not isinstance(entity, Resource):
+        if operation != DomainObjectOperation.changed \
+        or not isinstance(entity, Resource) \
+        or not getattr(entity, 'url_changed', False):
             return
         context = {
             "ignore_auth": True,


### PR DESCRIPTION
fix(dev): use `IDomainObjectModification` implementation;

- Use `IDomainObjectModification` instead of `IResourceUrlChange` for automagic exception handling.

Currently, the `notify` method from the `IResourceUrlChange` implementation is assuming that the Resource exists in the `resource_show` action call. But, at this point, other extensions (namely Validation running in sync mode) can delete the Resource from the session before it is committed. This would do a error here.

So using `IDomainObjectModification` instead, will automagically handle exceptions, logging them, and just passing so that normal operations will resume.