### PR TITLE
Skip empty lines instead of erroring

### DIFF
--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -146,7 +146,8 @@ def load_csv(csv_filepath, resource_id, mimetype='text/csv', logger=None):
 
     # Get the list of rows to skip. The rows in the tabulator stream are
     # numbered starting with 1.
-    skip_rows = list(range(1, header_offset + 1), {'type': 'preset', 'value': 'blank'})
+    skip_rows = list(range(1, header_offset + 1))
+    skip_rows.append({'type': 'preset', 'value': 'blank'})
 
     # Get the delimiter used in the file
     delimiter = stream.dialect.get('delimiter')
@@ -375,7 +376,8 @@ def load_table(table_filepath, resource_id, mimetype='text/csv', logger=None):
 
     # Get the list of rows to skip. The rows in the tabulator stream are
     # numbered starting with 1. We also want to skip the header row.
-    skip_rows = list(range(1, header_offset + 2), {'type': 'preset', 'value': 'blank'})
+    skip_rows = list(range(1, header_offset + 2))
+    skip_rows.append({'type': 'preset', 'value': 'blank'})
 
     TYPES, TYPE_MAPPING = get_types()
     types = type_guess(stream.sample[1:], types=TYPES, strict=True)

--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -146,7 +146,7 @@ def load_csv(csv_filepath, resource_id, mimetype='text/csv', logger=None):
 
     # Get the list of rows to skip. The rows in the tabulator stream are
     # numbered starting with 1.
-    skip_rows = list(range(1, header_offset + 1))
+    skip_rows = list(range(1, header_offset + 1), {'type': 'preset', 'value': 'blank'})
 
     # Get the delimiter used in the file
     delimiter = stream.dialect.get('delimiter')
@@ -347,12 +347,14 @@ def load_table(table_filepath, resource_id, mimetype='text/csv', logger=None):
     try:
         file_format = os.path.splitext(table_filepath)[1].strip('.')
         with UnknownEncodingStream(table_filepath, file_format, decoding_result,
+                                   skip_rows=[{'type': 'preset', 'value': 'blank'}],
                                    post_parse=[TypeConverter().convert_types]) as stream:
             header_offset, headers = headers_guess(stream.sample)
     except TabulatorException:
         try:
             file_format = mimetype.lower().split('/')[-1]
             with UnknownEncodingStream(table_filepath, file_format, decoding_result,
+                                       skip_rows=[{'type': 'preset', 'value': 'blank'}],
                                        post_parse=[TypeConverter().convert_types]) as stream:
                 header_offset, headers = headers_guess(stream.sample)
         except TabulatorException as e:
@@ -373,7 +375,7 @@ def load_table(table_filepath, resource_id, mimetype='text/csv', logger=None):
 
     # Get the list of rows to skip. The rows in the tabulator stream are
     # numbered starting with 1. We also want to skip the header row.
-    skip_rows = list(range(1, header_offset + 2))
+    skip_rows = list(range(1, header_offset + 2), {'type': 'preset', 'value': 'blank'})
 
     TYPES, TYPE_MAPPING = get_types()
     types = type_guess(stream.sample[1:], types=TYPES, strict=True)

--- a/ckanext/xloader/tests/samples/sample_with_empty_lines.csv
+++ b/ckanext/xloader/tests/samples/sample_with_empty_lines.csv
@@ -1,0 +1,8 @@
+date,temperature,place
+2011-01-01,1,Galway
+2011-01-02,-1,Galway
+2011-01-03,0,Galway
+2011-01-01,6,Berkeley
+,,Berkeley
+2011-01-03,5,
+

--- a/ckanext/xloader/tests/samples/sample_with_empty_lines.csv
+++ b/ckanext/xloader/tests/samples/sample_with_empty_lines.csv
@@ -3,6 +3,8 @@ date,temperature,place
 2011-01-02,-1,Galway
 2011-01-03,0,Galway
 2011-01-01,6,Berkeley
+
 ,,Berkeley
 2011-01-03,5,
+
 

--- a/ckanext/xloader/tests/test_loader.py
+++ b/ckanext/xloader/tests/test_loader.py
@@ -632,6 +632,18 @@ class TestLoadCsv(TestLoadBase):
         )
         assert len(self._get_records(Session, resource_id)) == 3
 
+    def test_with_empty_lines(self, Session):
+        csv_filepath = get_sample_filepath("sample_with_empty_lines.csv")
+        resource = factories.Resource()
+        resource_id = resource['id']
+        loader.load_csv(
+            csv_filepath,
+            resource_id=resource_id,
+            mimetype="text/csv",
+            logger=logger,
+        )
+        assert len(self._get_records(Session, resource_id)) == 6
+
     def test_with_quoted_commas(self, Session):
         csv_filepath = get_sample_filepath("sample_with_quoted_commas.csv")
         resource = factories.Resource()


### PR DESCRIPTION
Configure Tabulator to ignore empty rows, #206 