### PR TITLE
strip extra space for column name

### DIFF
--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -154,7 +154,11 @@ def load_csv(csv_filepath, resource_id, mimetype='text/csv', logger=None):
         logger.warning('Could not determine delimiter from file, use default ","')
         delimiter = ','
 
-    headers = [header.strip()[:MAX_COLUMN_LENGTH] for header in headers if header.strip()]
+    headers = [
+        header.strip()[:MAX_COLUMN_LENGTH].strip()
+        for header in headers
+        if header.strip()
+    ]
 
     # TODO worry about csv header name problems
     # e.g. duplicate names


### PR DESCRIPTION
If we have an extra space after truncating the column name, the validation from this function will fail:
```py
def is_valid_field_name(name: str):
    '''
    Check that field name is valid:
    * can't start or end with whitespace characters
    * can't start with underscore
    * can't contain double quote (")
    * can't be empty
    '''
    return (name and name == name.strip() and
            not name.startswith('_') and
            '"' not in name)
```