### PR TITLE
Fix automated PyPI publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -132,6 +132,16 @@ jobs:
 
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Validate tag version
+        if: ${{ startsWith(github.ref, 'refs/tags') }}
+        run: |
+          PYTHON_VERSION=$(grep "\bversion='[^']+'" | awk -F "'" '{print $2}')
+          if [ "${steps.version.outputs.version}" != "$PYTHON_VERSION" ]; then
+            echo "Version mismatch; tag version is [${steps.version.outputs.version}] but Python version is [$PYTHON_VERSION]"
+            exit 1
+          fi
+
       - name: Build package ${{ steps.version.outputs.reponame }} @ ${{ steps.version.outputs.version }}
         run: |
           pip install build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -100,32 +100,32 @@ jobs:
     name: Publish Package
     runs-on: ubuntu-latest
     environment:
-      name: ${{ github.event.inputs.environment }}
+      name: ${{ github.event.inputs.environment || 'pypi' }}
       url: ${{ steps.version.outputs.url }}
     concurrency:
       group: ${{ github.event.inputs.environment }}-deployment
       cancel-in-progress: false
-
+    env:
+      ENVIRONMENT: ${{ github.event.inputs.environment || 'pypi' }}
     steps:
       - name: Get Git Tag and set url from environment
         id: version
         run: |
           #!/bin/bash
 
-          ENVIRONMENT=$1
           TAG_VALUE=${GITHUB_REF/refs\/tags\//}
           echo "version=${TAG_VALUE}" >> $GITHUB_ENV
 
           # Extract the repository name (minus the owner/org)
           reponame=$(basename $GITHUB_REPOSITORY)
           echo "reponame=${reponame}" >> $GITHUB_OUTPUT
-          
-          if [ "$ENVIRONMENT" == "pypi" ]; then
-            url="https://pypi.com/p/$reponame"
-          elif [ "$1" == "testpypi" ]; then
+
+          if [ "$env.ENVIRONMENT" == "testpypi" ]; then
             url="https://test.pypi.com/p/$reponame"
+            echo "environment=${env.ENVIRONMENT}" >> $GITHUB_OUTPUT
           else
-           url=""
+            url="https://pypi.com/p/$reponame"
+            echo "environment=pypi" >> $GITHUB_OUTPUT
           fi
 
           echo "url=${url}" >> $GITHUB_OUTPUT
@@ -138,14 +138,14 @@ jobs:
           pip install twine
           python -m build
       - name: Publish package distributions to PyPI
-        if: ${{ startsWith(github.ref, 'refs/tags') && (github.event.inputs.environment == 'pypi' || github.event.inputs.environment == 'publish' ) && github.event.inputs.dryRun != 'true'}}
+        if: ${{ startsWith(github.ref, 'refs/tags') && steps.version.outputs.environment == 'pypi' && github.event.inputs.dryRun != 'true' }}
         uses: pypa/gh-action-pypi-publish@release/v1
 #        with:
 #          skip-existing: true
 #          verbose: true
 #          print-hash: true
       - name: Test Publish package distributions to PyPI
-        if: ${{ startsWith(github.ref, 'refs/tags') && github.event.inputs.environment == 'testpypi' && github.event.inputs.dryRun == 'true' }}
+        if: ${{ startsWith(github.ref, 'refs/tags') && steps.version.outputs.environment == 'testpypi' && github.event.inputs.dryRun == 'true' }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
   push:
   #On versioned releases
     tags:
-      - *.*.*
+      - '*.*.*'
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
     inputs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ on:
   push:
   #On versioned releases
     tags:
-      - v*.*.*
+      - *.*.*
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
- Remove unwanted 'v' from tag pattern
- Fix environment parameter to have a default value when automatically triggered
- Add validation that tag version matches Python version