### PR TITLE
Proof of concept for new config option: ckanext.xloader.site_url

### DIFF
--- a/ckanext/xloader/action.py
+++ b/ckanext/xloader/action.py
@@ -146,7 +146,7 @@ def xloader_submit(context, data_dict):
         "metadata": {
             "ignore_hash": data_dict.get("ignore_hash", False),
             "ckan_url": config.get("ckanext.xloader.site_url")
-            or config["ckan.site_url"],
+                or config["ckan.site_url"],
             "resource_id": res_id,
             "set_url_type": data_dict.get("set_url_type", False),
             "task_created": task["last_updated"],

--- a/ckanext/xloader/action.py
+++ b/ckanext/xloader/action.py
@@ -140,17 +140,18 @@ def xloader_submit(context, data_dict):
         qualified=True
     )
     data = {
-        'api_key': utils.get_xloader_user_apitoken(),
-        'job_type': 'xloader_to_datastore',
-        'result_url': callback_url,
-        'metadata': {
-            'ignore_hash': data_dict.get('ignore_hash', False),
-            'ckan_url': config['ckan.site_url'],
-            'resource_id': res_id,
-            'set_url_type': data_dict.get('set_url_type', False),
-            'task_created': task['last_updated'],
-            'original_url': resource_dict.get('url'),
-        }
+        "api_key": utils.get_xloader_user_apitoken(),
+        "job_type": "xloader_to_datastore",
+        "result_url": callback_url,
+        "metadata": {
+            "ignore_hash": data_dict.get("ignore_hash", False),
+            "ckan_url": config.get("ckanext.xloader.site_url")
+            or config["ckan.site_url"],
+            "resource_id": res_id,
+            "set_url_type": data_dict.get("set_url_type", False),
+            "task_created": task["last_updated"],
+            "original_url": resource_dict.get("url"),
+        },
     }
     if custom_queue != rq_jobs.DEFAULT_QUEUE_NAME:
         # Don't automatically retry if it's a custom run

--- a/ckanext/xloader/command.py
+++ b/ckanext/xloader/command.py
@@ -114,12 +114,11 @@ class XloaderCmd:
             'ignore_hash': True,
         }
         if sync:
-            data_dict['ckan_url'] = tk.config.get('ckan.site_url')
-            input_dict = {
-                'metadata': data_dict,
-                'api_key': 'TODO'
-            }
-            logger = logging.getLogger('ckanext.xloader.cli')
+            data_dict["ckan_url"] = tk.config.get(
+                "ckanext.xloader.site_url"
+            ) or tk.config.get("ckan.site_url")
+            input_dict = {"metadata": data_dict, "api_key": "TODO"}
+            logger = logging.getLogger("ckanext.xloader.cli")
             xloader_data_into_datastore_(input_dict, None, logger)
         else:
             if queue:

--- a/ckanext/xloader/config_declaration.yaml
+++ b/ckanext/xloader/config_declaration.yaml
@@ -2,6 +2,12 @@ version: 1
 groups:
   - annotation: ckanext-xloader settings
     options:
+      - key: ckanext.xloader.site_url
+        default:
+        description: |
+            Provide an alternate site URL for the xloader_submit action.
+            This is useful, for example, when the site is running within a docker network.
+        required: false
       - key: ckanext.xloader.jobs_db.uri
         default: sqlite:////tmp/xloader_jobs.db
         description: |
@@ -152,5 +158,3 @@ groups:
           they will also display "complete", "active", "inactive", and "unknown".
         type: bool
         required: false
-
-

--- a/ckanext/xloader/config_declaration.yaml
+++ b/ckanext/xloader/config_declaration.yaml
@@ -3,10 +3,12 @@ groups:
   - annotation: ckanext-xloader settings
     options:
       - key: ckanext.xloader.site_url
-        default:
+        example: http://ckan-dev:5000
+        default: http://ckan-dev:5000
         description: |
             Provide an alternate site URL for the xloader_submit action.
             This is useful, for example, when the site is running within a docker network.
+        validators: configured_default("ckan.site_url",None)
         required: false
       - key: ckanext.xloader.jobs_db.uri
         default: sqlite:////tmp/xloader_jobs.db

--- a/ckanext/xloader/config_declaration.yaml
+++ b/ckanext/xloader/config_declaration.yaml
@@ -4,7 +4,7 @@ groups:
     options:
       - key: ckanext.xloader.site_url
         example: http://ckan-dev:5000
-        default: http://ckan-dev:5000
+        default:
         description: |
             Provide an alternate site URL for the xloader_submit action.
             This is useful, for example, when the site is running within a docker network.

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -212,7 +212,11 @@ def xloader_data_into_datastore_(input, job_dict, logger):
         set_datastore_active(data, resource, logger)
         if 'result_url' in input:
             job_dict['status'] = 'running_but_viewable'
-            callback_xloader_hook(result_url=input['result_url'],
+            callback_url = config.get('ckanext.xloader.site_url') or config.get('ckan.site_url')
+            callback_url = urljoin(
+                callback_url.rstrip('/'), '/api/3/action/xloader_hook')
+            result_url = callback_url
+            callback_xloader_hook(result_url=result_url,
                                   api_key=api_key,
                                   job_dict=job_dict)
         logger.info('Data now available to users: %s', resource_ckan_url)

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -24,7 +24,7 @@ from ckan.plugins.toolkit import get_action, asbool, enqueue_job, ObjectNotFound
 
 from . import db, loader
 from .job_exceptions import JobError, HTTPError, DataTooBigError, FileCouldNotBeLoadedError
-from .utils import datastore_resource_exists, set_resource_metadata, get_ckan_url
+from .utils import datastore_resource_exists, set_resource_metadata, modify_resource_url, modify_ckan_url
 
 try:
     from ckan.lib.api_token import get_user_from_token
@@ -82,13 +82,10 @@ def xloader_data_into_datastore(input):
     # stillborn, for when xloader_submit is deciding whether another job would
     # be a duplicate or not
 
-    callback_url = get_ckan_url()
-    callback_url = urljoin(
-        callback_url.rstrip('/'), '/api/3/action/xloader_hook')
-
     job_dict = dict(metadata=input['metadata'],
                     status='running')
-    callback_xloader_hook(result_url=callback_url,
+
+    callback_xloader_hook(result_url=input['result_url'],
                           api_key=input['api_key'],
                           job_dict=job_dict)
 
@@ -150,7 +147,7 @@ def xloader_data_into_datastore(input):
         errored = True
     finally:
         # job_dict is defined in xloader_hook's docstring
-        is_saved_ok = callback_xloader_hook(result_url=callback_url,
+        is_saved_ok = callback_xloader_hook(result_url=input['result_url'],
                                             api_key=input['api_key'],
                                             job_dict=job_dict)
         errored = errored or not is_saved_ok
@@ -211,10 +208,7 @@ def xloader_data_into_datastore_(input, job_dict, logger):
         set_datastore_active(data, resource, logger)
         if 'result_url' in input:
             job_dict['status'] = 'running_but_viewable'
-            callback_url = get_ckan_url()
-            callback_url = urljoin(
-                callback_url.rstrip('/'), '/api/3/action/xloader_hook')
-            callback_xloader_hook(result_url=callback_url,
+            callback_xloader_hook(result_url=input['result_url'],
                                   api_key=api_key,
                                   job_dict=job_dict)
         logger.info('Data now available to users: %s', resource_ckan_url)
@@ -286,21 +280,16 @@ def _download_resource_data(resource, data, api_key, logger):
     data['datastore_contains_all_records_of_source_file'] = False
     which will be saved to the resource later on.
     '''
-    # check scheme
+ 
     url = resource.get('url')
-    url_parts = urlsplit(url)
+    url = modify_resource_url(url)
+    # check scheme
+    url_parts = urlsplit(url) 
     scheme = url_parts.scheme
     if scheme not in ('http', 'https', 'ftp'):
         raise JobError(
             'Only http, https, and ftp resources may be fetched.'
         )
-
-    resource_uri = urlunsplit(('', '', url_parts.path, url_parts.query, url_parts.fragment))
-    callback_url = get_ckan_url()
-    url = urljoin(
-        callback_url.rstrip('/'), resource_uri)
-    
-    url_parts = urlsplit(url) # reparse the url after the callback_url is set
 
     # fetch the resource data
     logger.info('Fetching from: {0}'.format(url))
@@ -455,7 +444,8 @@ def callback_xloader_hook(result_url, api_key, job_dict):
         else:
             header, key = 'Authorization', api_key
         headers[header] = key
-
+  
+    result_url = modify_ckan_url(result_url, job_dict['metadata']['ckan_url'])
     try:
         result = requests.post(
             result_url,

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -12,10 +12,12 @@ import traceback
 import sys
 
 from psycopg2 import errors
-from six.moves.urllib.parse import urlsplit
+from six.moves.urllib.parse import urlsplit, urlparse, urlunparse
 import requests
 from rq import get_current_job
 import sqlalchemy as sa
+
+from urllib.parse import urljoin, urlunsplit
 
 from ckan import model
 from ckan.plugins.toolkit import get_action, asbool, enqueue_job, ObjectNotFound, config
@@ -79,9 +81,15 @@ def xloader_data_into_datastore(input):
     # First flag that this task is running, to indicate the job is not
     # stillborn, for when xloader_submit is deciding whether another job would
     # be a duplicate or not
+
+    callback_url = config.get('ckanext.xloader.site_url') or config.get('ckan.site_url')
+    callback_url = urljoin(
+        callback_url.rstrip('/'), '/api/3/action/xloader_hook')
+    result_url = callback_url
+
     job_dict = dict(metadata=input['metadata'],
                     status='running')
-    callback_xloader_hook(result_url=input['result_url'],
+    callback_xloader_hook(result_url=result_url,
                           api_key=input['api_key'],
                           job_dict=job_dict)
 
@@ -143,7 +151,7 @@ def xloader_data_into_datastore(input):
         errored = True
     finally:
         # job_dict is defined in xloader_hook's docstring
-        is_saved_ok = callback_xloader_hook(result_url=input['result_url'],
+        is_saved_ok = callback_xloader_hook(result_url=result_url,
                                             api_key=input['api_key'],
                                             job_dict=job_dict)
         errored = errored or not is_saved_ok
@@ -284,6 +292,14 @@ def _download_resource_data(resource, data, api_key, logger):
         raise JobError(
             'Only http, https, and ftp resources may be fetched.'
         )
+
+    resource_uri = urlunsplit(('', '', url_parts.path, url_parts.query, url_parts.fragment))
+    callback_url = config.get('ckanext.xloader.site_url') or config.get('ckan.site_url')
+    callback_url = urljoin(
+        callback_url.rstrip('/'), resource_uri)
+    
+    url = callback_url
+    url_parts = urlsplit(url) # reparse the url after the callback_url is set
 
     # fetch the resource data
     logger.info('Fetching from: {0}'.format(url))

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -12,7 +12,7 @@ import traceback
 import sys
 
 from psycopg2 import errors
-from six.moves.urllib.parse import urlsplit, urlparse, urlunparse
+from six.moves.urllib.parse import urlsplit
 import requests
 from rq import get_current_job
 import sqlalchemy as sa

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -24,7 +24,7 @@ from ckan.plugins.toolkit import get_action, asbool, enqueue_job, ObjectNotFound
 
 from . import db, loader
 from .job_exceptions import JobError, HTTPError, DataTooBigError, FileCouldNotBeLoadedError
-from .utils import datastore_resource_exists, set_resource_metadata
+from .utils import datastore_resource_exists, set_resource_metadata, get_ckan_url
 
 try:
     from ckan.lib.api_token import get_user_from_token
@@ -82,14 +82,13 @@ def xloader_data_into_datastore(input):
     # stillborn, for when xloader_submit is deciding whether another job would
     # be a duplicate or not
 
-    callback_url = config.get('ckanext.xloader.site_url') or config.get('ckan.site_url')
+    callback_url = get_ckan_url()
     callback_url = urljoin(
         callback_url.rstrip('/'), '/api/3/action/xloader_hook')
-    result_url = callback_url
 
     job_dict = dict(metadata=input['metadata'],
                     status='running')
-    callback_xloader_hook(result_url=result_url,
+    callback_xloader_hook(result_url=callback_url,
                           api_key=input['api_key'],
                           job_dict=job_dict)
 
@@ -151,7 +150,7 @@ def xloader_data_into_datastore(input):
         errored = True
     finally:
         # job_dict is defined in xloader_hook's docstring
-        is_saved_ok = callback_xloader_hook(result_url=result_url,
+        is_saved_ok = callback_xloader_hook(result_url=callback_url,
                                             api_key=input['api_key'],
                                             job_dict=job_dict)
         errored = errored or not is_saved_ok
@@ -212,11 +211,10 @@ def xloader_data_into_datastore_(input, job_dict, logger):
         set_datastore_active(data, resource, logger)
         if 'result_url' in input:
             job_dict['status'] = 'running_but_viewable'
-            callback_url = config.get('ckanext.xloader.site_url') or config.get('ckan.site_url')
+            callback_url = get_ckan_url()
             callback_url = urljoin(
                 callback_url.rstrip('/'), '/api/3/action/xloader_hook')
-            result_url = callback_url
-            callback_xloader_hook(result_url=result_url,
+            callback_xloader_hook(result_url=callback_url,
                                   api_key=api_key,
                                   job_dict=job_dict)
         logger.info('Data now available to users: %s', resource_ckan_url)
@@ -298,11 +296,10 @@ def _download_resource_data(resource, data, api_key, logger):
         )
 
     resource_uri = urlunsplit(('', '', url_parts.path, url_parts.query, url_parts.fragment))
-    callback_url = config.get('ckanext.xloader.site_url') or config.get('ckan.site_url')
-    callback_url = urljoin(
+    callback_url = get_ckan_url()
+    url = urljoin(
         callback_url.rstrip('/'), resource_uri)
     
-    url = callback_url
     url_parts = urlsplit(url) # reparse the url after the callback_url is set
 
     # fetch the resource data

--- a/ckanext/xloader/plugin.py
+++ b/ckanext/xloader/plugin.py
@@ -61,13 +61,11 @@ class xloaderPlugin(plugins.SingletonPlugin):
         else:
             self.ignore_hash = False
 
-        for config_option in ("ckan.site_url",):
-            if not config_.get(config_option):
-                raise Exception(
-                    "Config option `{0}` must be set to use ckanext-xloader.".format(
-                        config_option
-                    )
-                )
+        site_url_configs = ("ckan.site_url", "ckanext.xloader.site_url")
+        if not any(site_url_configs):
+            raise Exception(
+                f"One of config options {site_url_configs} must be set to use ckanext-xloader."
+            )
 
     # IDomainObjectModification
 

--- a/ckanext/xloader/tests/test_jobs.py
+++ b/ckanext/xloader/tests/test_jobs.py
@@ -90,6 +90,66 @@ class TestXLoaderJobs(helpers.FunctionalRQTestBase):
         resource = helpers.call_action("resource_show", id=data["metadata"]["resource_id"])
         assert resource["datastore_contains_all_records_of_source_file"]
 
+    def test_download_resource_data_with_ckanext_xloader_site_url(self, cli, data):
+        # Set the ckanext.xloader.site_url in the config
+        with mock.patch.dict(toolkit.config, {'ckanext.xloader.site_url': 'http://xloader-site-url'}):
+            data['metadata']['original_url'] = 'http://xloader-site-url/resource.csv'
+            self.enqueue(jobs.xloader_data_into_datastore, [data])
+            with mock.patch("ckanext.xloader.jobs.get_response", get_response):
+                stdout = cli.invoke(ckan, ["jobs", "worker", "--burst"]).output
+                assert "Express Load completed" in stdout
+
+            resource = helpers.call_action("resource_show", id=data["metadata"]["resource_id"])
+            assert resource["datastore_contains_all_records_of_source_file"]
+
+    def test_download_resource_data_with_ckan_site_url(self, cli, data):
+        # Set the ckan.site_url in the config
+        with mock.patch.dict(toolkit.config, {'ckan.site_url': 'http://ckan-site-url'}):
+            data['metadata']['original_url'] = 'http://ckan-site-url/resource.csv'
+            self.enqueue(jobs.xloader_data_into_datastore, [data])
+            with mock.patch("ckanext.xloader.jobs.get_response", get_response):
+                stdout = cli.invoke(ckan, ["jobs", "worker", "--burst"]).output
+                assert "Express Load completed" in stdout
+
+            resource = helpers.call_action("resource_show", id=data["metadata"]["resource_id"])
+            assert resource["datastore_contains_all_records_of_source_file"]
+
+    def test_download_resource_data_with_different_original_url(self, cli, data):
+        # Set the ckan.site_url in the config
+        with mock.patch.dict(toolkit.config, {'ckan.site_url': 'http://ckan-site-url'}):
+            data['metadata']['original_url'] = 'http://external-site-url/resource.csv'
+            self.enqueue(jobs.xloader_data_into_datastore, [data])
+            with mock.patch("ckanext.xloader.jobs.get_response", get_response):
+                stdout = cli.invoke(ckan, ["jobs", "worker", "--burst"]).output
+                assert "Express Load completed" in stdout
+
+            resource = helpers.call_action("resource_show", id=data["metadata"]["resource_id"])
+            assert resource["datastore_contains_all_records_of_source_file"]
+
+    def test_callback_xloader_hook_with_ckanext_xloader_site_url(self, cli, data):
+        # Set the ckanext.xloader.site_url in the config
+        with mock.patch.dict(toolkit.config, {'ckanext.xloader.site_url': 'http://xloader-site-url'}):
+            data['result_url'] = 'http://xloader-site-url/api/3/action/xloader_hook'
+            self.enqueue(jobs.xloader_data_into_datastore, [data])
+            with mock.patch("ckanext.xloader.jobs.get_response", get_response):
+                stdout = cli.invoke(ckan, ["jobs", "worker", "--burst"]).output
+                assert "Express Load completed" in stdout
+
+            resource = helpers.call_action("resource_show", id=data["metadata"]["resource_id"])
+            assert resource["datastore_contains_all_records_of_source_file"]
+
+    def test_callback_xloader_hook_with_ckan_site_url(self, cli, data):
+        # Set the ckan.site_url in the config
+        with mock.patch.dict(toolkit.config, {'ckan.site_url': 'http://ckan-site-url'}):
+            data['result_url'] = 'http://ckan-site-url/api/3/action/xloader_hook'
+            self.enqueue(jobs.xloader_data_into_datastore, [data])
+            with mock.patch("ckanext.xloader.jobs.get_response", get_response):
+                stdout = cli.invoke(ckan, ["jobs", "worker", "--burst"]).output
+                assert "Express Load completed" in stdout
+
+            resource = helpers.call_action("resource_show", id=data["metadata"]["resource_id"])
+            assert resource["datastore_contains_all_records_of_source_file"]
+
     def test_xloader_ignore_hash(self, cli, data):
         self.enqueue(jobs.xloader_data_into_datastore, [data])
         with mock.patch("ckanext.xloader.jobs.get_response", get_response):

--- a/ckanext/xloader/tests/test_jobs.py
+++ b/ckanext/xloader/tests/test_jobs.py
@@ -59,17 +59,18 @@ def data(create_with_upload, apikey):
         "api.action", ver=3, logic_function="xloader_hook", qualified=True
     )
     return {
-        'api_key': apikey,
-        'job_type': 'xloader_to_datastore',
-        'result_url': callback_url,
-        'metadata': {
-            'ignore_hash': True,
-            'ckan_url': toolkit.config.get('ckan.site_url'),
-            'resource_id': resource["id"],
-            'set_url_type': False,
-            'task_created': datetime.utcnow().isoformat(),
-            'original_url': resource["url"],
-        }
+        "api_key": apikey,
+        "job_type": "xloader_to_datastore",
+        "result_url": callback_url,
+        "metadata": {
+            "ignore_hash": True,
+            "ckan_url": toolkit.config.get("ckanext.xloader.site_url")
+            or toolkit.config.get("ckan.site_url"),
+            "resource_id": resource["id"],
+            "set_url_type": False,
+            "task_created": datetime.utcnow().isoformat(),
+            "original_url": resource["url"],
+        },
     }
 
 

--- a/ckanext/xloader/utils.py
+++ b/ckanext/xloader/utils.py
@@ -107,6 +107,28 @@ def get_xloader_user_apitoken():
     return site_user["apikey"]
 
 
+def get_ckan_url():
+    """ Returns the CKAN URL.
+
+    ckan may be behind a proxy, or more likely, within a docker network.
+    This method returns the URL set in the config file for the CKAN instance.
+    Containers within the same network ie: XLoader will be able to communicate with CKAN using this URL.
+    """
+    ckan_url = config.get('ckanext.xloader.site_url', None)
+    if ckan_url:
+        return ckan_url
+
+    # Fall back to mandatory ckan.site_url
+    ckan_url = config.get('ckan.site_url')
+    if not ckan_url:
+        raise ValueError(
+            "The ckan.site_url configuration option is required but not set. "
+            "Please set this value in your CKAN configuration file."
+        )
+    
+    return ckan_url
+
+
 def set_resource_metadata(update_dict):
     '''
     Set appropriate datastore_active flag on CKAN resource.

--- a/ckanext/xloader/utils.py
+++ b/ckanext/xloader/utils.py
@@ -125,9 +125,8 @@ def modify_ckan_url(result_url: str, ckan_url: str) -> str:
     """
     parsed_url = urlparse(result_url)
     base_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
-    path_url = parsed_url.path
-
     if base_url != ckan_url:
+        path_url = parsed_url.path
         result_url = urljoin(ckan_url, path_url)
          
     return result_url

--- a/ckanext/xloader/utils.py
+++ b/ckanext/xloader/utils.py
@@ -2,6 +2,7 @@
 
 import json
 import datetime
+import re
 
 from six import text_type as str, binary_type
 
@@ -12,6 +13,8 @@ from decimal import Decimal
 
 import ckan.plugins as p
 from ckan.plugins.toolkit import config
+
+from urllib.parse import urljoin, urlunsplit, urlparse
 
 # resource.formats accepted by ckanext-xloader. Must be lowercase here.
 DEFAULT_FORMATS = [
@@ -107,26 +110,59 @@ def get_xloader_user_apitoken():
     return site_user["apikey"]
 
 
-def get_ckan_url():
-    """ Returns the CKAN URL.
+def modify_ckan_url(result_url: str, ckan_url: str) -> str:
+    """ Modifies a URL based on CKAN site URL comparison.
 
-    ckan may be behind a proxy, or more likely, within a docker network.
-    This method returns the URL set in the config file for the CKAN instance.
-    Containers within the same network ie: XLoader will be able to communicate with CKAN using this URL.
-    """
-    ckan_url = config.get('ckanext.xloader.site_url', None)
-    if ckan_url:
-        return ckan_url
-
-    # Fall back to mandatory ckan.site_url
-    ckan_url = config.get('ckan.site_url')
-    if not ckan_url:
-        raise ValueError(
-            "The ckan.site_url configuration option is required but not set. "
-            "Please set this value in your CKAN configuration file."
-        )
+    This function compares the base URL of a given result URL against a CKAN site URL.
+    If they differ, the result URL is modified to use the CKAN site URL as its base
+    while preserving the original path.
     
-    return ckan_url
+    Args:
+        result_url (str): The original URL to potentially modify
+        ckan_url (str): The base CKAN site URL to compare against
+    Returns:
+        str: The modified URL if base URLs differ, otherwise returns original URL unchanged 
+    """
+    parsed_url = urlparse(result_url)
+    base_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
+    path_url = parsed_url.path
+
+    if base_url != ckan_url:
+        result_url = urljoin(ckan_url, path_url)
+         
+    return result_url
+
+    
+def modify_resource_url(orig_ckan_url: str) -> str:
+    """Returns a potentially modified CKAN URL.
+
+    This function takes a CKAN URL and potentially modifies its base URL while preserving the path, 
+    query parameters, and fragments. The modification occurs only if two conditions are met:
+    1. The base URL of the input matches the configured CKAN site URL
+    2. An xloader_site_url is configured in the settings
+    
+    Args:
+        orig_ckan_url (str): The original CKAN URL to potentially modify
+    Returns:
+        str: Either the modified URL with new base URL from xloader_site_url, 
+             or the original URL if conditions aren't met
+    """
+    xloader_site_url = config.get('ckanext.xloader.site_url')
+    ckan_site_url = config.get('ckan.site_url')
+
+    parsed_url = urlparse(orig_ckan_url)
+    base_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
+
+    # If the base URL matches the CKAN site URL and xloader_site_url is set, modify the URL
+    if base_url == ckan_site_url and xloader_site_url:
+        modified_ckan_url = urljoin(xloader_site_url, parsed_url.path)
+        if parsed_url.query:
+            modified_ckan_url += f"?{parsed_url.query}"
+        if parsed_url.fragment:
+            modified_ckan_url += f"#{parsed_url.fragment}"
+        return modified_ckan_url
+
+    return orig_ckan_url
 
 
 def set_resource_metadata(update_dict):


### PR DESCRIPTION
We want to be able to communicate within a docker network without using the public site_url. This is a minimal proof of concept for achieving this.

Update: There are 2 scenario's where XLoader communicates to CKAN

**Scenario 1:** When it downloads the resource file from CKAN ie: in `_download_resource_data()`
**Scenario 2:** When it updates the status of the XLoader job ie: in `callback_xloader_hook()`

If the config option `ckanext.xloader.site_url` is set then **all** communication from XLoader to CKAN will use this URL. In scenario 1, if it's not set then the `ckan.site_url` config option will be used **unless** the download ie: `_download_resource_data()` `original_url` is different to `ckan_url` (ie: `ckan.site_url`) and in that case the `_download_resource_data()` download will use the `original_url` but all other communication back to CKAN (ie: scenario 2) will use the `ckan.site_url` option 