### PR TITLE
Feature/custom xloader site url rebased

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,6 +34,7 @@ jobs:
 
   validateVersion:
     runs-on: ubuntu-latest
+    if: github.repository == 'ckan/ckanext-xloader'
     steps:
       - uses: actions/checkout@v4
 
@@ -52,79 +53,10 @@ jobs:
             exit 1
           fi
 
-  lint:
-    needs: validateVersion
-    if: github.repository == 'ckan/ckanext-xloader'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
-
-      - name: Install requirements
-        run: pip install flake8 pycodestyle
-
-      - name: Check syntax
-        run: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics --extend-exclude ckan
-
   test:
-    needs: lint
-    strategy:
-      matrix:
-        include: #ckan-image see https://github.com/ckan/ckan-docker-base, ckan-version controls other image tags
-          - ckan-version: "2.11"
-            ckan-image: "2.11-py3.10"
-          - ckan-version: "2.10"
-            ckan-image: "2.10-py3.10"
-          #- ckan-version: "master" Publish does not care about master
-          #  ckan-image: "master"
-      fail-fast: false
-
-    name: CKAN ${{ matrix.ckan-version }}
-    runs-on: ubuntu-latest
-    container:
-      image: ckan/ckan-dev:${{ matrix.ckan-image }}
-      options: --user root
-    services:
-      solr:
-        image: ckan/ckan-solr:${{ matrix.ckan-version }}-solr9
-      postgres:
-        image: ckan/ckan-postgres-dev:${{ matrix.ckan-version }}
-        env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: postgres
-        ports:
-          - 5432:5432
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
-      redis:
-          image: redis:3
-    env:
-      CKAN_SQLALCHEMY_URL: postgresql://ckan_default:pass@postgres/ckan_test
-      CKAN_DATASTORE_WRITE_URL: postgresql://datastore_write:pass@postgres/datastore_test
-      CKAN_DATASTORE_READ_URL: postgresql://datastore_read:pass@postgres/datastore_test
-      CKAN_SOLR_URL: http://solr:8983/solr/ckan
-      CKAN_REDIS_URL: redis://redis:6379/1
-
-    steps:
-    - uses: actions/checkout@v4
-    - if: ${{ matrix.ckan-version == 2.9 }}
-      run: pip install "setuptools>=44.1.0,<71"
-    - name: Install requirements
-      run: |
-        pip install -r requirements.txt
-        pip install -r dev-requirements.txt
-        pip install -e .
-        pip install -U requests[security]
-        # Replace default path to CKAN core config file with the one on the container
-        sed -i -e 's/use = config:.*/use = config:\/srv\/app\/src\/ckan\/test-core.ini/' test.ini
-    - name: Setup extension (CKAN >= 2.9)
-      run: |
-        ckan -c test.ini db init
-    - name: Run tests
-      run: pytest --ckan-ini=test.ini --cov=ckanext.xloader --disable-warnings ckanext/xloader/tests
+    needs: validateVersion
+    name: Test
+    uses: ./.github/workflows/test.yml # Call the reusable workflow
 
   publishSkipped:
     if: github.repository != 'ckan/ckanext-xloader'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
             experimental: true  # master is unstable, good to know if we are compatible or not
       fail-fast: false
 
-    name: CKAN ${{ matrix.ckan-version }}
+    name: ${{ matrix.experimental && '**Fail_Ignored** ' || '' }} CKAN ${{ matrix.ckan-version }}
     runs-on: ubuntu-latest
     container:
       image: ckan/ckan-dev:${{ matrix.ckan-image }}
@@ -65,12 +65,7 @@ jobs:
     - uses: actions/checkout@v4
       continue-on-error: ${{ matrix.experimental }}
 
-    - name: Pin setuptools for ckan 2.9 only
-      if: ${{ matrix.ckan-version == 2.9 }}
-      run: pip install "setuptools>=44.1.0,<71"
-      continue-on-error: ${{ matrix.experimental }}
-
-    - name: Install requirements
+    - name: ${{ matrix.experimental && '**Fail_Ignored** ' || '' }} Install requirements
       continue-on-error: ${{ matrix.experimental }}
       run: |
         pip install -r requirements.txt
@@ -80,16 +75,20 @@ jobs:
         # Replace default path to CKAN core config file with the one on the container
         sed -i -e 's/use = config:.*/use = config:\/srv\/app\/src\/ckan\/test-core.ini/' test.ini
 
-    - name: Setup extension
+    - name: ${{ matrix.experimental && '**Fail_Ignored** ' || '' }} Setup extension
       continue-on-error: ${{ matrix.experimental }}
       run: |
         ckan -c test.ini db init
+        ckan -c test.ini user add ckan_admin email=ckan_admin@localhost password="AbCdEf12345!@#%"
+        ckan -c test.ini sysadmin add ckan_admin
+        ckan config-tool test.ini "ckanext.xloader.api_token=$(ckan -c test.ini user token add ckan_admin xloader | tail -n 1 | tr -d '\t')"
+        ckan -c test.ini user list
 
-    - name: Run tests
+    - name: ${{ matrix.experimental && '**Fail_Ignored** ' || '' }} Run tests
       continue-on-error: ${{ matrix.experimental }}
       run: pytest --ckan-ini=test.ini --cov=ckanext.xloader --disable-warnings ckanext/xloader/tests --junit-xml=/tmp/artifacts/junit/results.xml
 
-    - name: Test Summary
+    - name: ${{ matrix.experimental && '**Fail_Ignored** ' || '' }} Test Summary
       uses: test-summary/action@v2
       continue-on-error: ${{ matrix.experimental }}
       with:

--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ To install XLoader:
     execute jobs against the server:
 
         ckanext.xloader.api_token = <your-CKAN-generated-API-Token>
+        ckan config-tool test.ini "ckanext.xloader.api_token=$(ckan -c test.ini user token add ckan_admin xloader | tail -n 1 | tr -d '\t')"
 
 6.  If it is a production server, you'll want to store jobs info in a
     more robust database than the default sqlite file. It can happily
@@ -220,8 +221,7 @@ ckanext.xloader.api_token = eyJ0eXAiOiJKV1QiLCJh.eyJqdGkiOiJ0M2VNUFlQWFg0VU.8QgV
 
 Default value: none
 
-Uses a specific API token for the xloader_submit action instead of the
-apikey of the site_user. It's mandatory starting from CKAN 2.10. You can get one
+It's mandatory starting from CKAN 2.10. You can get one
 running the command `ckan user token add {USER_NAME} xloader -q`
 
 

--- a/ckanext/xloader/action.py
+++ b/ckanext/xloader/action.py
@@ -47,6 +47,7 @@ def xloader_submit(context, data_dict):
     :rtype: bool
     '''
     p.toolkit.check_access('xloader_submit', context, data_dict)
+    api_key = utils.get_xloader_user_apitoken()
     custom_queue = data_dict.pop('queue', rq_jobs.DEFAULT_QUEUE_NAME)
     schema = context.get('schema', ckanext.xloader.schema.xloader_submit_schema())
     data_dict, errors = _validate(data_dict, schema, context)
@@ -147,7 +148,7 @@ def xloader_submit(context, data_dict):
         qualified=True
     )
     data = {
-        'api_key': utils.get_xloader_user_apitoken(),
+        'api_key': api_key,
         'job_type': 'xloader_to_datastore',
         'result_url': callback_url,
         'metadata': {

--- a/ckanext/xloader/action.py
+++ b/ckanext/xloader/action.py
@@ -153,7 +153,7 @@ def xloader_submit(context, data_dict):
         "metadata": {
             "ignore_hash": data_dict.get("ignore_hash", False),
             "ckan_url": config.get("ckanext.xloader.site_url")
-            or config["ckan.site_url"],
+                or config["ckan.site_url"],
             "resource_id": res_id,
             "set_url_type": data_dict.get("set_url_type", False),
             "task_created": task["last_updated"],

--- a/ckanext/xloader/action.py
+++ b/ckanext/xloader/action.py
@@ -147,18 +147,17 @@ def xloader_submit(context, data_dict):
         qualified=True
     )
     data = {
-        "api_key": utils.get_xloader_user_apitoken(),
-        "job_type": "xloader_to_datastore",
-        "result_url": callback_url,
-        "metadata": {
-            "ignore_hash": data_dict.get("ignore_hash", False),
-            "ckan_url": config.get("ckanext.xloader.site_url")
-                or config["ckan.site_url"],
-            "resource_id": res_id,
-            "set_url_type": data_dict.get("set_url_type", False),
-            "task_created": task["last_updated"],
-            "original_url": resource_dict.get("url"),
-        },
+        'api_key': utils.get_xloader_user_apitoken(),
+        'job_type': 'xloader_to_datastore',
+        'result_url': callback_url,
+        'metadata': {
+            'ignore_hash': data_dict.get('ignore_hash', False),
+            'ckan_url': config['ckan.site_url'],
+            'resource_id': res_id,
+            'set_url_type': data_dict.get('set_url_type', False),
+            'task_created': task['last_updated'],
+            'original_url': resource_dict.get('url'),
+        }
     }
     if custom_queue != rq_jobs.DEFAULT_QUEUE_NAME:
         # Don't automatically retry if it's a custom run

--- a/ckanext/xloader/action.py
+++ b/ckanext/xloader/action.py
@@ -147,17 +147,18 @@ def xloader_submit(context, data_dict):
         qualified=True
     )
     data = {
-        'api_key': utils.get_xloader_user_apitoken(),
-        'job_type': 'xloader_to_datastore',
-        'result_url': callback_url,
-        'metadata': {
-            'ignore_hash': data_dict.get('ignore_hash', False),
-            'ckan_url': config['ckan.site_url'],
-            'resource_id': res_id,
-            'set_url_type': data_dict.get('set_url_type', False),
-            'task_created': task['last_updated'],
-            'original_url': resource_dict.get('url'),
-        }
+        "api_key": utils.get_xloader_user_apitoken(),
+        "job_type": "xloader_to_datastore",
+        "result_url": callback_url,
+        "metadata": {
+            "ignore_hash": data_dict.get("ignore_hash", False),
+            "ckan_url": config.get("ckanext.xloader.site_url")
+            or config["ckan.site_url"],
+            "resource_id": res_id,
+            "set_url_type": data_dict.get("set_url_type", False),
+            "task_created": task["last_updated"],
+            "original_url": resource_dict.get("url"),
+        },
     }
     if custom_queue != rq_jobs.DEFAULT_QUEUE_NAME:
         # Don't automatically retry if it's a custom run

--- a/ckanext/xloader/command.py
+++ b/ckanext/xloader/command.py
@@ -5,7 +5,7 @@ import logging
 import ckan.plugins.toolkit as tk
 
 from ckanext.xloader.jobs import xloader_data_into_datastore_
-from ckanext.xloader.utils import XLoaderFormats
+from ckanext.xloader.utils import XLoaderFormats, get_xloader_user_apitoken
 
 
 class XloaderCmd:
@@ -114,11 +114,12 @@ class XloaderCmd:
             'ignore_hash': True,
         }
         if sync:
-            data_dict["ckan_url"] = tk.config.get(
-                "ckanext.xloader.site_url"
-            ) or tk.config.get("ckan.site_url")
-            input_dict = {"metadata": data_dict, "api_key": "TODO"}
-            logger = logging.getLogger("ckanext.xloader.cli")
+            data_dict['ckan_url'] = tk.config.get('ckan.site_url')
+            input_dict = {
+                'metadata': data_dict,
+                'api_key': get_xloader_user_apitoken()
+            }
+            logger = logging.getLogger('ckanext.xloader.cli')
             xloader_data_into_datastore_(input_dict, None, logger)
         else:
             if queue:

--- a/ckanext/xloader/command.py
+++ b/ckanext/xloader/command.py
@@ -114,12 +114,11 @@ class XloaderCmd:
             'ignore_hash': True,
         }
         if sync:
-            data_dict['ckan_url'] = tk.config.get('ckan.site_url')
-            input_dict = {
-                'metadata': data_dict,
-                'api_key': 'TODO'
-            }
-            logger = logging.getLogger('ckanext.xloader.cli')
+            data_dict["ckan_url"] = tk.config.get(
+                "ckanext.xloader.site_url"
+            ) or tk.config.get("ckan.site_url")
+            input_dict = {"metadata": data_dict, "api_key": "TODO"}
+            logger = logging.getLogger("ckanext.xloader.cli")
             xloader_data_into_datastore_(input_dict, None, logger)
         else:
             if queue:

--- a/ckanext/xloader/config_declaration.yaml
+++ b/ckanext/xloader/config_declaration.yaml
@@ -8,7 +8,16 @@ groups:
         description: |
             Provide an alternate site URL for the xloader_submit action.
             This is useful, for example, when the site is running within a docker network.
+            Note: This setting will not alter path. i.e ckan.root_path
         validators: configured_default("ckan.site_url",None)
+        required: false
+      - key: ckanext.xloader.site_url_ignore_path_regex
+        example: "(/PathToS3HostOriginIWantToGoDirectTo|/anotherPath)"
+        default:
+        description: |
+            Provide the ability to ignore paths which can't be mapped to alternative site URL for resource access.
+            This is useful, for example, when the site is running within a docker network and the cdn front door has 
+            Blob storage mapped to another path on the same domain.
         required: false
       - key: ckanext.xloader.jobs_db.uri
         default: sqlite:////tmp/xloader_jobs.db

--- a/ckanext/xloader/config_declaration.yaml
+++ b/ckanext/xloader/config_declaration.yaml
@@ -30,9 +30,9 @@ groups:
         example: eyJ0eXAiOiJKV1QiLCJh.eyJqdGkiOiJ0M2VNUFlQWFg0VU.8QgV8em4RA
         description: |
             Uses a specific API token for the xloader_submit action instead of the
-            apikey of the site_user. Will be mandatory when dropping support for
-            CKAN 2.9.
-        required: false
+            apikey of the site_user.
+        default: 'NOT_SET'
+        required: true
       - key: ckanext.xloader.formats
         example: csv application/csv xls application/vnd.ms-excel
         description: |

--- a/ckanext/xloader/config_declaration.yaml
+++ b/ckanext/xloader/config_declaration.yaml
@@ -2,6 +2,12 @@ version: 1
 groups:
   - annotation: ckanext-xloader settings
     options:
+      - key: ckanext.xloader.site_url
+        default:
+        description: |
+            Provide an alternate site URL for the xloader_submit action.
+            This is useful, for example, when the site is running within a docker network.
+        required: false
       - key: ckanext.xloader.jobs_db.uri
         default: sqlite:////tmp/xloader_jobs.db
         description: |
@@ -171,5 +177,3 @@ groups:
           they will also display "complete", "active", "inactive", and "unknown".
         type: bool
         required: false
-
-

--- a/ckanext/xloader/config_declaration.yaml
+++ b/ckanext/xloader/config_declaration.yaml
@@ -3,10 +3,12 @@ groups:
   - annotation: ckanext-xloader settings
     options:
       - key: ckanext.xloader.site_url
-        default:
+        example: http://ckan-dev:5000
+        default: http://ckan-dev:5000
         description: |
             Provide an alternate site URL for the xloader_submit action.
             This is useful, for example, when the site is running within a docker network.
+        validators: configured_default("ckan.site_url",None)
         required: false
       - key: ckanext.xloader.jobs_db.uri
         default: sqlite:////tmp/xloader_jobs.db

--- a/ckanext/xloader/config_declaration.yaml
+++ b/ckanext/xloader/config_declaration.yaml
@@ -9,7 +9,6 @@ groups:
             Provide an alternate site URL for the xloader_submit action.
             This is useful, for example, when the site is running within a docker network.
             Note: This setting will not alter path. i.e ckan.root_path
-        validators: configured_default("ckan.site_url",None)
         required: false
       - key: ckanext.xloader.site_url_ignore_path_regex
         example: "(/PathToS3HostOriginIWantToGoDirectTo|/anotherPath)"

--- a/ckanext/xloader/config_declaration.yaml
+++ b/ckanext/xloader/config_declaration.yaml
@@ -4,7 +4,7 @@ groups:
     options:
       - key: ckanext.xloader.site_url
         example: http://ckan-dev:5000
-        default: http://ckan-dev:5000
+        default:
         description: |
             Provide an alternate site URL for the xloader_submit action.
             This is useful, for example, when the site is running within a docker network.

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -25,10 +25,8 @@ from . import db, loader
 from .job_exceptions import JobError, HTTPError, DataTooBigError, FileCouldNotBeLoadedError
 from .utils import datastore_resource_exists, set_resource_metadata, modify_input_url
 
-try:
-    from ckan.lib.api_token import get_user_from_token
-except ImportError:
-    get_user_from_token = None
+
+from ckan.lib.api_token import get_user_from_token
 
 log = logging.getLogger(__name__)
 
@@ -511,19 +509,9 @@ def update_resource(resource, patch_only=False):
 
 def _get_user_from_key(api_key_or_token):
     """ Gets the user using the API Token or API Key.
-
-    This method provides backwards compatibility for CKAN 2.9 that
-    supported both methods and previous CKAN versions supporting
-    only API Keys.
     """
-    user = None
-    if get_user_from_token:
-        user = get_user_from_token(api_key_or_token)
-    if not user:
-        user = model.Session.query(model.User).filter_by(
-            apikey=api_key_or_token
-        ).first()
-    return user
+    return get_user_from_token(api_key_or_token)
+
 
 
 def get_resource_and_dataset(resource_id, api_key):

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -12,7 +12,7 @@ import traceback
 import sys
 
 from psycopg2 import errors
-from six.moves.urllib.parse import urlsplit, urlparse, urlunparse
+from six.moves.urllib.parse import urlsplit
 import requests
 from rq import get_current_job
 from rq.timeouts import JobTimeoutException

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -220,7 +220,11 @@ def xloader_data_into_datastore_(input, job_dict, logger):
         set_datastore_active(data, resource, logger)
         if 'result_url' in input:
             job_dict['status'] = 'running_but_viewable'
-            callback_xloader_hook(result_url=input['result_url'],
+            callback_url = config.get('ckanext.xloader.site_url') or config.get('ckan.site_url')
+            callback_url = urljoin(
+                callback_url.rstrip('/'), '/api/3/action/xloader_hook')
+            result_url = callback_url
+            callback_xloader_hook(result_url=result_url,
                                   api_key=api_key,
                                   job_dict=job_dict)
         logger.info('Data now available to users: %s', resource_ckan_url)

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -300,9 +300,7 @@ def _download_resource_data(resource, data, api_key, logger):
     data['datastore_contains_all_records_of_source_file'] = False
     which will be saved to the resource later on.
     '''
- 
-    url = resource.get('url')
-    url = modify_resource_url(url)
+    url = modify_resource_url(resource.get('url'))
     # check scheme
     url_parts = urlsplit(url) 
     scheme = url_parts.scheme

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -25,7 +25,7 @@ from ckan.plugins.toolkit import get_action, asbool, enqueue_job, ObjectNotFound
 
 from . import db, loader
 from .job_exceptions import JobError, HTTPError, DataTooBigError, FileCouldNotBeLoadedError
-from .utils import datastore_resource_exists, set_resource_metadata, get_ckan_url
+from .utils import datastore_resource_exists, set_resource_metadata, modify_resource_url, modify_ckan_url
 
 try:
     from ckan.lib.api_token import get_user_from_token
@@ -83,13 +83,10 @@ def xloader_data_into_datastore(input):
     # stillborn, for when xloader_submit is deciding whether another job would
     # be a duplicate or not
 
-    callback_url = get_ckan_url()
-    callback_url = urljoin(
-        callback_url.rstrip('/'), '/api/3/action/xloader_hook')
-
     job_dict = dict(metadata=input['metadata'],
                     status='running')
-    callback_xloader_hook(result_url=callback_url,
+
+    callback_xloader_hook(result_url=input['result_url'],
                           api_key=input['api_key'],
                           job_dict=job_dict)
 
@@ -152,7 +149,7 @@ def xloader_data_into_datastore(input):
         errored = True
     finally:
         # job_dict is defined in xloader_hook's docstring
-        is_saved_ok = callback_xloader_hook(result_url=callback_url,
+        is_saved_ok = callback_xloader_hook(result_url=input['result_url'],
                                             api_key=input['api_key'],
                                             job_dict=job_dict)
         errored = errored or not is_saved_ok
@@ -219,10 +216,7 @@ def xloader_data_into_datastore_(input, job_dict, logger):
         set_datastore_active(data, resource, logger)
         if 'result_url' in input:
             job_dict['status'] = 'running_but_viewable'
-            callback_url = get_ckan_url()
-            callback_url = urljoin(
-                callback_url.rstrip('/'), '/api/3/action/xloader_hook')
-            callback_xloader_hook(result_url=callback_url,
+            callback_xloader_hook(result_url=input['result_url'],
                                   api_key=api_key,
                                   job_dict=job_dict)
         logger.info('Data now available to users: %s', resource_ckan_url)
@@ -306,21 +300,16 @@ def _download_resource_data(resource, data, api_key, logger):
     data['datastore_contains_all_records_of_source_file'] = False
     which will be saved to the resource later on.
     '''
-    # check scheme
+ 
     url = resource.get('url')
-    url_parts = urlsplit(url)
+    url = modify_resource_url(url)
+    # check scheme
+    url_parts = urlsplit(url) 
     scheme = url_parts.scheme
     if scheme not in ('http', 'https', 'ftp'):
         raise JobError(
             'Only http, https, and ftp resources may be fetched.'
         )
-
-    resource_uri = urlunsplit(('', '', url_parts.path, url_parts.query, url_parts.fragment))
-    callback_url = get_ckan_url()
-    url = urljoin(
-        callback_url.rstrip('/'), resource_uri)
-    
-    url_parts = urlsplit(url) # reparse the url after the callback_url is set
 
     # fetch the resource data
     logger.info('Fetching from: {0}'.format(url))
@@ -481,7 +470,8 @@ def callback_xloader_hook(result_url, api_key, job_dict):
         else:
             header, key = 'Authorization', api_key
         headers[header] = key
-
+  
+    result_url = modify_ckan_url(result_url, job_dict['metadata']['ckan_url'])
     try:
         result = requests.post(
             result_url,

--- a/ckanext/xloader/plugin.py
+++ b/ckanext/xloader/plugin.py
@@ -17,13 +17,7 @@ try:
 except ImportError:
     HAS_IPIPE_VALIDATION = False
 
-try:
-    config_declarations = toolkit.blanket.config_declarations
-except AttributeError:
-    # CKAN 2.9 does not have config_declarations.
-    # Remove when dropping support.
-    def config_declarations(cls):
-        return cls
+config_declarations = toolkit.blanket.config_declarations
 
 if toolkit.check_ckan_version(min_version='2.11'):
     from ckanext.datastore.interfaces import IDataDictionaryForm

--- a/ckanext/xloader/plugin.py
+++ b/ckanext/xloader/plugin.py
@@ -76,13 +76,11 @@ class xloaderPlugin(plugins.SingletonPlugin):
         else:
             self.ignore_hash = False
 
-        for config_option in ("ckan.site_url",):
-            if not config_.get(config_option):
-                raise Exception(
-                    "Config option `{0}` must be set to use ckanext-xloader.".format(
-                        config_option
-                    )
-                )
+        site_url_configs = ("ckan.site_url", "ckanext.xloader.site_url")
+        if not any(site_url_configs):
+            raise Exception(
+                f"One of config options {site_url_configs} must be set to use ckanext-xloader."
+            )
 
     # IPipeValidation
 

--- a/ckanext/xloader/plugin.py
+++ b/ckanext/xloader/plugin.py
@@ -76,12 +76,6 @@ class xloaderPlugin(plugins.SingletonPlugin):
         else:
             self.ignore_hash = False
 
-        site_url_configs = ("ckan.site_url", "ckanext.xloader.site_url")
-        if not any(site_url_configs):
-            raise Exception(
-                f"One of config options {site_url_configs} must be set to use ckanext-xloader."
-            )
-
     # IPipeValidation
 
     def receive_validation_report(self, validation_report):

--- a/ckanext/xloader/schema.py
+++ b/ckanext/xloader/schema.py
@@ -17,11 +17,7 @@ boolean_validator = get_validator('boolean_validator')
 int_validator = get_validator('int_validator')
 OneOf = get_validator('OneOf')
 ignore_not_sysadmin = get_validator('ignore_not_sysadmin')
-
-if p.toolkit.check_ckan_version('2.9'):
-    unicode_safe = get_validator('unicode_safe')
-else:
-    unicode_safe = str
+unicode_safe = get_validator('unicode_safe')
 
 
 def xloader_submit_schema():

--- a/ckanext/xloader/tests/test_jobs.py
+++ b/ckanext/xloader/tests/test_jobs.py
@@ -71,17 +71,17 @@ def data(create_with_upload, apikey):
         "api.action", ver=3, logic_function="xloader_hook", qualified=True
     )
     return {
-        "api_key": apikey,
-        "job_type": "xloader_to_datastore",
-        "result_url": callback_url,
-        "metadata": {
-            "ignore_hash": True,
-            "ckan_url": toolkit.config.get("ckanext.xloader.site_url", toolkit.config.get("ckan.site_url")),
-            "resource_id": resource["id"],
-            "set_url_type": False,
-            "task_created": datetime.utcnow().isoformat(),
-            "original_url": resource["url"],
-        },
+        'api_key': apikey,
+        'job_type': 'xloader_to_datastore',
+        'result_url': callback_url,
+        'metadata': {
+            'ignore_hash': True,
+            'ckan_url': toolkit.config.get('ckan.site_url'),
+            'resource_id': resource["id"],
+            'set_url_type': False,
+            'task_created': datetime.utcnow().isoformat(),
+            'original_url': resource["url"],
+        }
     }
 
 

--- a/ckanext/xloader/tests/test_jobs.py
+++ b/ckanext/xloader/tests/test_jobs.py
@@ -76,8 +76,7 @@ def data(create_with_upload, apikey):
         "result_url": callback_url,
         "metadata": {
             "ignore_hash": True,
-            "ckan_url": toolkit.config.get("ckanext.xloader.site_url")
-            or toolkit.config.get("ckan.site_url"),
+            "ckan_url": toolkit.config.get("ckanext.xloader.site_url", toolkit.config.get("ckan.site_url")),
             "resource_id": resource["id"],
             "set_url_type": False,
             "task_created": datetime.utcnow().isoformat(),

--- a/ckanext/xloader/tests/test_jobs.py
+++ b/ckanext/xloader/tests/test_jobs.py
@@ -71,17 +71,18 @@ def data(create_with_upload, apikey):
         "api.action", ver=3, logic_function="xloader_hook", qualified=True
     )
     return {
-        'api_key': apikey,
-        'job_type': 'xloader_to_datastore',
-        'result_url': callback_url,
-        'metadata': {
-            'ignore_hash': True,
-            'ckan_url': toolkit.config.get('ckan.site_url'),
-            'resource_id': resource["id"],
-            'set_url_type': False,
-            'task_created': datetime.utcnow().isoformat(),
-            'original_url': resource["url"],
-        }
+        "api_key": apikey,
+        "job_type": "xloader_to_datastore",
+        "result_url": callback_url,
+        "metadata": {
+            "ignore_hash": True,
+            "ckan_url": toolkit.config.get("ckanext.xloader.site_url")
+            or toolkit.config.get("ckan.site_url"),
+            "resource_id": resource["id"],
+            "set_url_type": False,
+            "task_created": datetime.utcnow().isoformat(),
+            "original_url": resource["url"],
+        },
     }
 
 

--- a/ckanext/xloader/tests/test_jobs.py
+++ b/ckanext/xloader/tests/test_jobs.py
@@ -48,13 +48,7 @@ def _get_temp_files(dir='/tmp'):
 
 @pytest.fixture
 def apikey():
-    if toolkit.check_ckan_version(min_version="2.10"):
-        sysadmin = factories.SysadminWithToken()
-    else:
-        # To provide support with CKAN 2.9
-        sysadmin = factories.Sysadmin()
-        sysadmin["token"] = get_xloader_user_apitoken()
-
+    sysadmin = factories.SysadminWithToken()
     return sysadmin["token"]
 
 
@@ -103,65 +97,62 @@ class TestXLoaderJobs(helpers.FunctionalRQTestBase):
         resource = helpers.call_action("resource_show", id=data["metadata"]["resource_id"])
         assert resource["datastore_contains_all_records_of_source_file"]
 
+    # Set the ckanext.xloader.site_url in the config
+    @pytest.mark.ckan_config("ckanext.xloader.site_url", 'http://xloader-site-url')
     def test_download_resource_data_with_ckanext_xloader_site_url(self, cli, data):
-        # Set the ckanext.xloader.site_url in the config
-        with mock.patch.dict(toolkit.config, {'ckanext.xloader.site_url': 'http://xloader-site-url'}):
-            data['metadata']['original_url'] = 'http://xloader-site-url/resource.csv'
-            self.enqueue(jobs.xloader_data_into_datastore, [data])
-            with mock.patch("ckanext.xloader.jobs.get_response", get_response):
-                stdout = cli.invoke(ckan, ["jobs", "worker", "--burst"]).output
-                assert "Express Load completed" in stdout
 
-            resource = helpers.call_action("resource_show", id=data["metadata"]["resource_id"])
-            assert resource["datastore_contains_all_records_of_source_file"]
+        data['metadata']['original_url'] = 'http://xloader-site-url/resource.csv'
+        self.enqueue(jobs.xloader_data_into_datastore, [data])
+        with mock.patch("ckanext.xloader.jobs.get_response", get_response):
+            stdout = cli.invoke(ckan, ["jobs", "worker", "--burst"]).output
+            assert "Express Load completed" in stdout
 
+        resource = helpers.call_action("resource_show", id=data["metadata"]["resource_id"])
+        assert resource["datastore_contains_all_records_of_source_file"]
+
+    @pytest.mark.ckan_config("ckanext.site_url", 'http://ckan-site-url')
     def test_download_resource_data_with_ckan_site_url(self, cli, data):
-        # Set the ckan.site_url in the config
-        with mock.patch.dict(toolkit.config, {'ckan.site_url': 'http://ckan-site-url'}):
-            data['metadata']['original_url'] = 'http://ckan-site-url/resource.csv'
-            self.enqueue(jobs.xloader_data_into_datastore, [data])
-            with mock.patch("ckanext.xloader.jobs.get_response", get_response):
-                stdout = cli.invoke(ckan, ["jobs", "worker", "--burst"]).output
-                assert "Express Load completed" in stdout
+        data['metadata']['original_url'] = 'http://ckan-site-url/resource.csv'
+        self.enqueue(jobs.xloader_data_into_datastore, [data])
+        with mock.patch("ckanext.xloader.jobs.get_response", get_response):
+            stdout = cli.invoke(ckan, ["jobs", "worker", "--burst"]).output
+            assert "Express Load completed" in stdout
 
-            resource = helpers.call_action("resource_show", id=data["metadata"]["resource_id"])
-            assert resource["datastore_contains_all_records_of_source_file"]
+        resource = helpers.call_action("resource_show", id=data["metadata"]["resource_id"])
+        assert resource["datastore_contains_all_records_of_source_file"]
 
+    @pytest.mark.ckan_config("ckanext.site_url", 'http://ckan-site-url')
     def test_download_resource_data_with_different_original_url(self, cli, data):
-        # Set the ckan.site_url in the config
-        with mock.patch.dict(toolkit.config, {'ckan.site_url': 'http://ckan-site-url'}):
-            data['metadata']['original_url'] = 'http://external-site-url/resource.csv'
-            self.enqueue(jobs.xloader_data_into_datastore, [data])
-            with mock.patch("ckanext.xloader.jobs.get_response", get_response):
-                stdout = cli.invoke(ckan, ["jobs", "worker", "--burst"]).output
-                assert "Express Load completed" in stdout
+        data['metadata']['original_url'] = 'http://external-site-url/resource.csv'
+        self.enqueue(jobs.xloader_data_into_datastore, [data])
+        with mock.patch("ckanext.xloader.jobs.get_response", get_response):
+            stdout = cli.invoke(ckan, ["jobs", "worker", "--burst"]).output
+            assert "Express Load completed" in stdout
 
-            resource = helpers.call_action("resource_show", id=data["metadata"]["resource_id"])
-            assert resource["datastore_contains_all_records_of_source_file"]
+        resource = helpers.call_action("resource_show", id=data["metadata"]["resource_id"])
+        assert resource["datastore_contains_all_records_of_source_file"]
 
+    @pytest.mark.ckan_config("ckanext.xloader.site_url", 'http://xloader-site-url')
     def test_callback_xloader_hook_with_ckanext_xloader_site_url(self, cli, data):
-        # Set the ckanext.xloader.site_url in the config
-        with mock.patch.dict(toolkit.config, {'ckanext.xloader.site_url': 'http://xloader-site-url'}):
-            data['result_url'] = 'http://xloader-site-url/api/3/action/xloader_hook'
-            self.enqueue(jobs.xloader_data_into_datastore, [data])
-            with mock.patch("ckanext.xloader.jobs.get_response", get_response):
-                stdout = cli.invoke(ckan, ["jobs", "worker", "--burst"]).output
-                assert "Express Load completed" in stdout
+        data['result_url'] = 'http://xloader-site-url/api/3/action/xloader_hook'
+        self.enqueue(jobs.xloader_data_into_datastore, [data])
+        with mock.patch("ckanext.xloader.jobs.get_response", get_response):
+            stdout = cli.invoke(ckan, ["jobs", "worker", "--burst"]).output
+            assert "Express Load completed" in stdout
 
-            resource = helpers.call_action("resource_show", id=data["metadata"]["resource_id"])
-            assert resource["datastore_contains_all_records_of_source_file"]
+        resource = helpers.call_action("resource_show", id=data["metadata"]["resource_id"])
+        assert resource["datastore_contains_all_records_of_source_file"]
 
+    @pytest.mark.ckan_config("ckanext.site_url", 'http://ckan-site-url')
     def test_callback_xloader_hook_with_ckan_site_url(self, cli, data):
-        # Set the ckan.site_url in the config
-        with mock.patch.dict(toolkit.config, {'ckan.site_url': 'http://ckan-site-url'}):
-            data['result_url'] = 'http://ckan-site-url/api/3/action/xloader_hook'
-            self.enqueue(jobs.xloader_data_into_datastore, [data])
-            with mock.patch("ckanext.xloader.jobs.get_response", get_response):
-                stdout = cli.invoke(ckan, ["jobs", "worker", "--burst"]).output
-                assert "Express Load completed" in stdout
+        data['result_url'] = 'http://ckan-site-url/api/3/action/xloader_hook'
+        self.enqueue(jobs.xloader_data_into_datastore, [data])
+        with mock.patch("ckanext.xloader.jobs.get_response", get_response):
+            stdout = cli.invoke(ckan, ["jobs", "worker", "--burst"]).output
+            assert "Express Load completed" in stdout
 
-            resource = helpers.call_action("resource_show", id=data["metadata"]["resource_id"])
-            assert resource["datastore_contains_all_records_of_source_file"]
+        resource = helpers.call_action("resource_show", id=data["metadata"]["resource_id"])
+        assert resource["datastore_contains_all_records_of_source_file"]
 
     def test_xloader_ignore_hash(self, cli, data):
         self.enqueue(jobs.xloader_data_into_datastore, [data])

--- a/ckanext/xloader/tests/test_jobs.py
+++ b/ckanext/xloader/tests/test_jobs.py
@@ -104,6 +104,66 @@ class TestXLoaderJobs(helpers.FunctionalRQTestBase):
         resource = helpers.call_action("resource_show", id=data["metadata"]["resource_id"])
         assert resource["datastore_contains_all_records_of_source_file"]
 
+    def test_download_resource_data_with_ckanext_xloader_site_url(self, cli, data):
+        # Set the ckanext.xloader.site_url in the config
+        with mock.patch.dict(toolkit.config, {'ckanext.xloader.site_url': 'http://xloader-site-url'}):
+            data['metadata']['original_url'] = 'http://xloader-site-url/resource.csv'
+            self.enqueue(jobs.xloader_data_into_datastore, [data])
+            with mock.patch("ckanext.xloader.jobs.get_response", get_response):
+                stdout = cli.invoke(ckan, ["jobs", "worker", "--burst"]).output
+                assert "Express Load completed" in stdout
+
+            resource = helpers.call_action("resource_show", id=data["metadata"]["resource_id"])
+            assert resource["datastore_contains_all_records_of_source_file"]
+
+    def test_download_resource_data_with_ckan_site_url(self, cli, data):
+        # Set the ckan.site_url in the config
+        with mock.patch.dict(toolkit.config, {'ckan.site_url': 'http://ckan-site-url'}):
+            data['metadata']['original_url'] = 'http://ckan-site-url/resource.csv'
+            self.enqueue(jobs.xloader_data_into_datastore, [data])
+            with mock.patch("ckanext.xloader.jobs.get_response", get_response):
+                stdout = cli.invoke(ckan, ["jobs", "worker", "--burst"]).output
+                assert "Express Load completed" in stdout
+
+            resource = helpers.call_action("resource_show", id=data["metadata"]["resource_id"])
+            assert resource["datastore_contains_all_records_of_source_file"]
+
+    def test_download_resource_data_with_different_original_url(self, cli, data):
+        # Set the ckan.site_url in the config
+        with mock.patch.dict(toolkit.config, {'ckan.site_url': 'http://ckan-site-url'}):
+            data['metadata']['original_url'] = 'http://external-site-url/resource.csv'
+            self.enqueue(jobs.xloader_data_into_datastore, [data])
+            with mock.patch("ckanext.xloader.jobs.get_response", get_response):
+                stdout = cli.invoke(ckan, ["jobs", "worker", "--burst"]).output
+                assert "Express Load completed" in stdout
+
+            resource = helpers.call_action("resource_show", id=data["metadata"]["resource_id"])
+            assert resource["datastore_contains_all_records_of_source_file"]
+
+    def test_callback_xloader_hook_with_ckanext_xloader_site_url(self, cli, data):
+        # Set the ckanext.xloader.site_url in the config
+        with mock.patch.dict(toolkit.config, {'ckanext.xloader.site_url': 'http://xloader-site-url'}):
+            data['result_url'] = 'http://xloader-site-url/api/3/action/xloader_hook'
+            self.enqueue(jobs.xloader_data_into_datastore, [data])
+            with mock.patch("ckanext.xloader.jobs.get_response", get_response):
+                stdout = cli.invoke(ckan, ["jobs", "worker", "--burst"]).output
+                assert "Express Load completed" in stdout
+
+            resource = helpers.call_action("resource_show", id=data["metadata"]["resource_id"])
+            assert resource["datastore_contains_all_records_of_source_file"]
+
+    def test_callback_xloader_hook_with_ckan_site_url(self, cli, data):
+        # Set the ckan.site_url in the config
+        with mock.patch.dict(toolkit.config, {'ckan.site_url': 'http://ckan-site-url'}):
+            data['result_url'] = 'http://ckan-site-url/api/3/action/xloader_hook'
+            self.enqueue(jobs.xloader_data_into_datastore, [data])
+            with mock.patch("ckanext.xloader.jobs.get_response", get_response):
+                stdout = cli.invoke(ckan, ["jobs", "worker", "--burst"]).output
+                assert "Express Load completed" in stdout
+
+            resource = helpers.call_action("resource_show", id=data["metadata"]["resource_id"])
+            assert resource["datastore_contains_all_records_of_source_file"]
+
     def test_xloader_ignore_hash(self, cli, data):
         self.enqueue(jobs.xloader_data_into_datastore, [data])
         with mock.patch("ckanext.xloader.jobs.get_response", get_response):

--- a/ckanext/xloader/tests/test_utils.py
+++ b/ckanext/xloader/tests/test_utils.py
@@ -1,0 +1,47 @@
+import pytest
+from unittest.mock import patch
+
+from ckanext.xloader import utils
+
+@pytest.mark.parametrize("result_url, ckan_url, expected", [
+    ("https://example.com/resource/123", "https://ckan.example.org", "https://ckan.example.org/resource/123"),
+    ("https://ckan.example.org/resource/123", "https://ckan.example.org", "https://ckan.example.org/resource/123"),
+    ("http://old-ckan.com/resource/456", "http://new-ckan.com", "http://new-ckan.com/resource/456"),
+    ("https://sub.example.com/path", "https://ckan.example.com", "https://ckan.example.com/path"),
+    ("ftp://fileserver.com/file", "https://ckan.example.com", "ftp://fileserver.com/file"),
+    ("https://ckan.example.org/resource/789", "https://xloader.example.org", "https://xloader.example.org/resource/789"),
+    ("https://ckan.example.org/dataset/data", "https://xloader.example.org", "https://xloader.example.org/dataset/data"),
+    ("https://ckan.example.org/resource/123?foo=bar", "https://xloader.example.org", "https://xloader.example.org/resource/123?foo=bar"),
+    ("https://ckan.example.org/dataset/456#section", "https://xloader.example.org", "https://xloader.example.org/dataset/456#section"),
+    ("https://ckan.example.org/resource/123?param=value&other=123", "https://xloader.example.org", "https://xloader.example.org/resource/123?param=value&other=123"),
+    ("https://ckan.example.org/resource/partial#fragment", "https://xloader.example.org", "https://xloader.example.org/resource/partial#fragment"),
+    ("https://ckan.example.org/path/to/data?key=value#section", "https://xloader.example.org", "https://xloader.example.org/path/to/data?key=value#section"),
+])
+def test_modify_ckan_url(result_url, ckan_url, expected):
+    assert utils.modify_ckan_url(result_url, ckan_url) == expected
+
+
+def test_modify_ckan_url_no_change():
+    url = "https://ckan.example.com/dataset"
+    assert utils.modify_ckan_url(url, "https://ckan.example.com") == url
+
+
+@pytest.mark.parametrize("orig_ckan_url, ckan_site_url, xloader_site_url, expected", [
+    ("https://ckan.example.org/resource/789", "https://ckan.example.org", "https://xloader.example.org", "https://xloader.example.org/resource/789"),
+    ("https://ckan.example.org/dataset/data", "https://ckan.example.org", "https://xloader.example.org", "https://xloader.example.org/dataset/data"),
+    ("https://ckan.example.org/resource/123?foo=bar", "https://ckan.example.org", "https://xloader.example.org", "https://xloader.example.org/resource/123?foo=bar"),
+    ("https://ckan.example.org/dataset/456#section", "https://ckan.example.org", "https://xloader.example.org", "https://xloader.example.org/dataset/456#section"),
+    ("https://other-site.com/resource/999", "https://ckan.example.org", "https://xloader.example.org", "https://other-site.com/resource/999"),
+    ("https://ckan.example.org/resource/123?param=value&other=123", "https://ckan.example.org", "https://xloader.example.org", "https://xloader.example.org/resource/123?param=value&other=123"),
+    ("https://ckan.example.org/resource/partial#fragment", "https://ckan.example.org", "https://xloader.example.org", "https://xloader.example.org/resource/partial#fragment"),
+    ("https://ckan.example.org/path/to/data?key=value#section", "https://ckan.example.org", "https://xloader.example.org", "https://xloader.example.org/path/to/data?key=value#section"),
+])
+def test_modify_resource_url(orig_ckan_url, ckan_site_url, xloader_site_url, expected):
+    with patch.dict("your_module.toolkit.config", {"ckan.site_url": ckan_site_url, "ckanext.xloader.site_url": xloader_site_url}):
+        assert utils.modify_resource_url(orig_ckan_url) == expected
+
+
+def test_modify_resource_url_no_xloader_site():
+    url = "https://ckan.example.org/dataset"
+    with patch.dict("your_module.toolkit.config", {"ckan.site_url": "https://ckan.example.org", "ckanext.xloader.site_url": None}):
+        assert utils.modify_resource_url(url) == url

--- a/ckanext/xloader/tests/test_utils.py
+++ b/ckanext/xloader/tests/test_utils.py
@@ -1,14 +1,17 @@
 import pytest
 from unittest.mock import patch
-
+from ckan.plugins import toolkit
 from ckanext.xloader import utils
+
 
 @pytest.mark.parametrize("result_url, ckan_url, expected", [
     ("https://example.com/resource/123", "https://ckan.example.org", "https://ckan.example.org/resource/123"),
+    ("https://example.com/resource/123", "http://127.0.0.1:3001", "http://127.0.0.1:3001/resource/123"),
+    ("https://example.com/resource/123", "http://127.0.0.1:3001/pathnotadded", "http://127.0.0.1:3001/resource/123"),
     ("https://ckan.example.org/resource/123", "https://ckan.example.org", "https://ckan.example.org/resource/123"),
     ("http://old-ckan.com/resource/456", "http://new-ckan.com", "http://new-ckan.com/resource/456"),
     ("https://sub.example.com/path", "https://ckan.example.com", "https://ckan.example.com/path"),
-    ("ftp://fileserver.com/file", "https://ckan.example.com", "ftp://fileserver.com/file"),
+    ("ftp://fileserver.com/file", "https://ckan.example.com", "ftp://fileserver.com/file"), ##should never happen
     ("https://ckan.example.org/resource/789", "https://xloader.example.org", "https://xloader.example.org/resource/789"),
     ("https://ckan.example.org/dataset/data", "https://xloader.example.org", "https://xloader.example.org/dataset/data"),
     ("https://ckan.example.org/resource/123?foo=bar", "https://xloader.example.org", "https://xloader.example.org/resource/123?foo=bar"),
@@ -17,31 +20,43 @@ from ckanext.xloader import utils
     ("https://ckan.example.org/resource/partial#fragment", "https://xloader.example.org", "https://xloader.example.org/resource/partial#fragment"),
     ("https://ckan.example.org/path/to/data?key=value#section", "https://xloader.example.org", "https://xloader.example.org/path/to/data?key=value#section"),
 ])
-def test_modify_ckan_url(result_url, ckan_url, expected):
-    assert utils.modify_ckan_url(result_url, ckan_url) == expected
+def test_private_modify_url(result_url, ckan_url, expected):
+    assert utils._modify_url(result_url, ckan_url) == expected
 
 
 def test_modify_ckan_url_no_change():
     url = "https://ckan.example.com/dataset"
-    assert utils.modify_ckan_url(url, "https://ckan.example.com") == url
+    assert utils._modify_url(url, "https://ckan.example.com") == url
 
 
-@pytest.mark.parametrize("orig_ckan_url, ckan_site_url, xloader_site_url, expected", [
-    ("https://ckan.example.org/resource/789", "https://ckan.example.org", "https://xloader.example.org", "https://xloader.example.org/resource/789"),
-    ("https://ckan.example.org/dataset/data", "https://ckan.example.org", "https://xloader.example.org", "https://xloader.example.org/dataset/data"),
-    ("https://ckan.example.org/resource/123?foo=bar", "https://ckan.example.org", "https://xloader.example.org", "https://xloader.example.org/resource/123?foo=bar"),
-    ("https://ckan.example.org/dataset/456#section", "https://ckan.example.org", "https://xloader.example.org", "https://xloader.example.org/dataset/456#section"),
-    ("https://other-site.com/resource/999", "https://ckan.example.org", "https://xloader.example.org", "https://other-site.com/resource/999"),
-    ("https://ckan.example.org/resource/123?param=value&other=123", "https://ckan.example.org", "https://xloader.example.org", "https://xloader.example.org/resource/123?param=value&other=123"),
-    ("https://ckan.example.org/resource/partial#fragment", "https://ckan.example.org", "https://xloader.example.org", "https://xloader.example.org/resource/partial#fragment"),
-    ("https://ckan.example.org/path/to/data?key=value#section", "https://ckan.example.org", "https://xloader.example.org", "https://xloader.example.org/path/to/data?key=value#section"),
+@pytest.mark.parametrize("input_url, ckan_site_url, xloader_site_url, is_altered, expected", [
+    ("https://ckan.example.org/resource/789", "https://ckan.example.org", "https://xloader.example.org", True, "https://xloader.example.org/resource/789"),
+    ("https://ckan.example.org/resource/789", "https://ckan.example.org", "http://127.0.0.1:3012", True, "http://127.0.0.1:3012/resource/789"),
+    ("https://ckan.example.org/dataset/data", "https://ckan.example.org", "https://xloader.example.org", True, "https://xloader.example.org/dataset/data"),
+    ("https://ckan.example.org/resource/123?foo=bar", "https://ckan.example.org", "https://xloader.example.org", True, "https://xloader.example.org/resource/123?foo=bar"),
+    ("https://ckan.example.org/dataset/456#section", "https://ckan.example.org", "https://xloader.example.org", True, "https://xloader.example.org/dataset/456#section"),
+    ("https://other-site.com/resource/999", "https://ckan.example.org", "https://xloader.example.org", False, ""),
+    ("https://ckan.example.org/resource/123?param=value&other=123", "https://ckan.example.org", "https://xloader.example.org", True, "https://xloader.example.org/resource/123?param=value&other=123"),
+    ("https://ckan.example.org/resource/partial#fragment", "https://ckan.example.org", "https://xloader.example.org", True, "https://xloader.example.org/resource/partial#fragment"),
+    ("https://ckan.example.org/path/to/data?key=value#section", "https://ckan.example.org", "https://xloader.example.org", True, "https://xloader.example.org/path/to/data?key=value#section"),
+    ("https://ckan.example.org/path/to/data?key=value#section", "https://ckan.example.org", "http://localhost:3000", True, "http://localhost:3000/path/to/data?key=value#section"),
+    ("https://ckan.example.org/blackListedPathToS3HostOrigin?key=value#section", "https://ckan.example.org", "https://xloader.example.org", False, ""),
+    ("ftp://ckan.example.org/dataset/456#section", "https://ckan.example.org", "https://xloader.example.org", False, ""),
 ])
-def test_modify_resource_url(orig_ckan_url, ckan_site_url, xloader_site_url, expected):
-    with patch.dict("your_module.toolkit.config", {"ckan.site_url": ckan_site_url, "ckanext.xloader.site_url": xloader_site_url}):
-        assert utils.modify_resource_url(orig_ckan_url) == expected
+def test_modify_input_url(input_url, ckan_site_url, xloader_site_url, is_altered, expected):
+    with patch.dict(toolkit.config,
+                    {"ckan.site_url": ckan_site_url,
+                     "ckanext.xloader.site_url": xloader_site_url,
+                     "ckanext.xloader.site_url_ignore_path_regex": "(/blackListedPathToS3HostOrigin|/anotherpath)"}):
+        response = utils.modify_input_url(input_url)
+        if is_altered:
+            assert response == expected
+        else:
+            assert response == input_url
 
 
-def test_modify_resource_url_no_xloader_site():
+
+def test_modify_input_url_no_xloader_site():
     url = "https://ckan.example.org/dataset"
-    with patch.dict("your_module.toolkit.config", {"ckan.site_url": "https://ckan.example.org", "ckanext.xloader.site_url": None}):
-        assert utils.modify_resource_url(url) == url
+    with patch.dict(toolkit.config, {"ckan.site_url": "https://ckan.example.org", "ckanext.xloader.site_url": None}):
+        assert utils.modify_input_url(url) == url

--- a/ckanext/xloader/tests/test_utils.py
+++ b/ckanext/xloader/tests/test_utils.py
@@ -3,6 +3,10 @@ from unittest.mock import patch
 from ckan.plugins import toolkit
 from ckanext.xloader import utils
 
+def test_private_modify_url_no_change():
+    url = "https://ckan.example.com/dataset"
+    assert utils._modify_url(url, "https://ckan.example.com") == url
+
 
 @pytest.mark.parametrize("result_url, ckan_url, expected", [
     ("https://example.com/resource/123", "https://ckan.example.org", "https://ckan.example.org/resource/123"),
@@ -19,14 +23,13 @@ from ckanext.xloader import utils
     ("https://ckan.example.org/resource/123?param=value&other=123", "https://xloader.example.org", "https://xloader.example.org/resource/123?param=value&other=123"),
     ("https://ckan.example.org/resource/partial#fragment", "https://xloader.example.org", "https://xloader.example.org/resource/partial#fragment"),
     ("https://ckan.example.org/path/to/data?key=value#section", "https://xloader.example.org", "https://xloader.example.org/path/to/data?key=value#section"),
+    ("", "", ""),
+    ("", "http://127.0.0.1:5000", ""),
+    (None, None, None),
+    (None, "http://127.0.0.1:5000", None),
 ])
 def test_private_modify_url(result_url, ckan_url, expected):
     assert utils._modify_url(result_url, ckan_url) == expected
-
-
-def test_modify_ckan_url_no_change():
-    url = "https://ckan.example.com/dataset"
-    assert utils._modify_url(url, "https://ckan.example.com") == url
 
 
 @pytest.mark.parametrize("input_url, ckan_site_url, xloader_site_url, is_altered, expected", [
@@ -42,6 +45,11 @@ def test_modify_ckan_url_no_change():
     ("https://ckan.example.org/path/to/data?key=value#section", "https://ckan.example.org", "http://localhost:3000", True, "http://localhost:3000/path/to/data?key=value#section"),
     ("https://ckan.example.org/blackListedPathToS3HostOrigin?key=value#section", "https://ckan.example.org", "https://xloader.example.org", False, ""),
     ("ftp://ckan.example.org/dataset/456#section", "https://ckan.example.org", "https://xloader.example.org", False, ""),
+    ("https://ckan.example.org/dataset/456#section", "https://ckan.example.org", "", False, ""),
+    ("", "http://127.0.0.1:5000", None, False, ""),
+    ("", "http://127.0.0.1:5000", "", False, ""),
+    (None, "http://127.0.0.1:5000", None, False, ""),
+    (None, "http://127.0.0.1:5000", "", False, ""),
 ])
 def test_modify_input_url(input_url, ckan_site_url, xloader_site_url, is_altered, expected):
     with patch.dict(toolkit.config,

--- a/ckanext/xloader/utils.py
+++ b/ckanext/xloader/utils.py
@@ -170,12 +170,11 @@ def get_xloader_user_apitoken():
     method returns the api_token set in the config file and defaults to the
     site_user.
     """
-    api_token = p.toolkit.config.get('ckanext.xloader.api_token', None)
-    if api_token:
+    api_token = p.toolkit.config.get('ckanext.xloader.api_token')
+    if api_token and api_token != 'NOT_SET':
         return api_token
+    raise p.toolkit.ValidationError({u'ckanext.xloader.api_token': u'NOT_SET, please provide valid api token'})
 
-    site_user = p.toolkit.get_action('get_site_user')({'ignore_auth': True}, {})
-    return site_user["apikey"]
 
 
 def _modify_url(input_url: str, base_url: str) -> str:

--- a/ckanext/xloader/utils.py
+++ b/ckanext/xloader/utils.py
@@ -175,6 +175,28 @@ def get_xloader_user_apitoken():
     return site_user["apikey"]
 
 
+def get_ckan_url():
+    """ Returns the CKAN URL.
+
+    ckan may be behind a proxy, or more likely, within a docker network.
+    This method returns the URL set in the config file for the CKAN instance.
+    Containers within the same network ie: XLoader will be able to communicate with CKAN using this URL.
+    """
+    ckan_url = config.get('ckanext.xloader.site_url', None)
+    if ckan_url:
+        return ckan_url
+
+    # Fall back to mandatory ckan.site_url
+    ckan_url = config.get('ckan.site_url')
+    if not ckan_url:
+        raise ValueError(
+            "The ckan.site_url configuration option is required but not set. "
+            "Please set this value in your CKAN configuration file."
+        )
+    
+    return ckan_url
+
+
 def set_resource_metadata(update_dict):
     '''
     Set appropriate datastore_active flag on CKAN resource.

--- a/ckanext/xloader/utils.py
+++ b/ckanext/xloader/utils.py
@@ -193,9 +193,8 @@ def modify_ckan_url(result_url: str, ckan_url: str) -> str:
     """
     parsed_url = urlparse(result_url)
     base_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
-    path_url = parsed_url.path
-
     if base_url != ckan_url:
+        path_url = parsed_url.path
         result_url = urljoin(ckan_url, path_url)
          
     return result_url


### PR DESCRIPTION
supersedes: pwalsh:feature/custom-xloader-site-url #234

We want to be able to communicate within a docker network without using the public site_url. This is a minimal proof of concept for achieving this.

Update: There are 2 scenario's where XLoader communicates to CKAN

Scenario 1: When it downloads the resource file from CKAN ie: in _download_resource_data()
Scenario 2: When it updates the status of the XLoader job ie: in callback_xloader_hook()

If the config option ckanext.xloader.site_url is set then all communication from XLoader to CKAN will use this URL. In scenario 1, if it's not set then the ckan.site_url config option will be used unless the download ie: _download_resource_data() original_url is different to ckan_url (ie: ckan.site_url) and in that case the _download_resource_data() download will use the original_url but all other communication back to CKAN (ie: scenario 2) will use the ckan.site_url option