### PR TITLE
Backport features from QGOV fork

### DIFF
--- a/ckanext/xloader/helpers.py
+++ b/ckanext/xloader/helpers.py
@@ -40,7 +40,7 @@ def is_resource_supported_by_xloader(res_dict, check_access=True):
         try:
             is_supported_url_type = url_type not in toolkit.h.datastore_rw_resource_url_types()
         except AttributeError:
-            is_supported_url_type = (url_type == 'upload')
+            is_supported_url_type = (url_type in ['upload', 'None'])
     else:
         is_supported_url_type = True
     return (is_supported_format or is_datastore_active) and user_has_access and is_supported_url_type

--- a/ckanext/xloader/job_exceptions.py
+++ b/ckanext/xloader/job_exceptions.py
@@ -53,6 +53,7 @@ class LoaderError(JobError):
     '''Exception that's raised if a load fails'''
     pass
 
+
 class XLoaderTimeoutError(JobError):
     """Custom timeout exception that can be retried"""
     pass

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -323,18 +323,18 @@ def xloader_data_into_datastore_(input, job_dict, logger):
                 logger.info('Trying again with tabulator')
                 tabulator_load()
     except JobTimeoutException:
-        try:
-            tmp_file.close()
-        except FileNotFoundError:
-            pass
         logger.warning('Job timed out after %ss', RETRIED_JOB_TIMEOUT)
         raise JobError('Job timed out after {}s'.format(RETRIED_JOB_TIMEOUT))
     except FileCouldNotBeLoadedError as e:
         logger.warning('Loading excerpt for this format not supported.')
         logger.error('Loading file raised an error: %s', e)
         raise JobError('Loading file raised an error: {}'.format(e))
-
-    tmp_file.close()
+    finally:
+        try:
+            tmp_file.close()
+            os.remove(tmp_file.name)
+        except FileNotFoundError:
+            pass
 
     logger.info('Express Load completed')
 

--- a/ckanext/xloader/jobs.py
+++ b/ckanext/xloader/jobs.py
@@ -18,7 +18,6 @@ from rq import get_current_job
 from rq.timeouts import JobTimeoutException
 import sqlalchemy as sa
 
-from ckan import model
 from ckan.plugins.toolkit import get_action, asbool, enqueue_job, ObjectNotFound, config, h
 
 from . import db, loader
@@ -439,7 +438,7 @@ def _download_resource_data(resource, data, api_key, logger):
     except requests.exceptions.Timeout:
         logger.warning('URL time out after %ss', DOWNLOAD_TIMEOUT)
         raise XLoaderTimeoutError('Connection timed out after {}s'.format(
-                       DOWNLOAD_TIMEOUT))
+                                  DOWNLOAD_TIMEOUT))
     except requests.exceptions.RequestException as e:
         tmp_file.close()
         try:
@@ -525,7 +524,7 @@ def callback_xloader_hook(result_url, api_key, job_dict):
 
     try:
         result = requests.post(
-            modify_input_url(result_url), # modify with local config
+            modify_input_url(result_url),  # modify with local config
             data=json.dumps(job_dict, cls=DatetimeJsonEncoder),
             verify=SSL_VERIFY,
             headers=headers)
@@ -570,7 +569,6 @@ def _get_user_from_key(api_key_or_token):
     """ Gets the user using the API Token or API Key.
     """
     return get_user_from_token(api_key_or_token)
-
 
 
 def get_resource_and_dataset(resource_id, api_key):

--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -688,7 +688,7 @@ def _populate_fulltext(connection, resource_id, fields, logger):
         connection: Database connection object
         resource_id (str): The datastore table identifier
         fields (list): List of dicts with column 'id' (name) and 'type' 
-                      (text/numeric/timestamp)
+            (text/numeric/timestamp)
         logger: Logger instance for progress tracking
         
     Note:
@@ -726,8 +726,8 @@ def _populate_fulltext(connection, resource_id, fields, logger):
                                 identifier(field['id'])
                                 + ('::text' if field['type'] != 'text' else '')  # Cast non-text types
                             )
-                            for field in fields
-                            if not field['id'].startswith('_')  # Skip system columns like _id, _full_text
+                            # Skip system columns like _id, _full_text
+                            for field in fields if not field['id'].startswith('_')
                         ),
                         first=start,
                         end=start + chunks

--- a/ckanext/xloader/schema.py
+++ b/ckanext/xloader/schema.py
@@ -1,7 +1,5 @@
 # encoding: utf-8
 
-from six import text_type as str
-
 import ckan.plugins as p
 import ckanext.datastore.logic.schema as dsschema
 

--- a/ckanext/xloader/tests/samples/simple-with-extra-column.csv
+++ b/ckanext/xloader/tests/samples/simple-with-extra-column.csv
@@ -1,0 +1,7 @@
+date,temperature,place,foo
+2011-01-01,1,Galway,1
+2011-01-02,-1,Galway,2
+2011-01-03,0,Galway,3
+2011-01-01,6,Berkeley,4
+,,Berkeley,5
+2011-01-03,5,,6

--- a/ckanext/xloader/tests/test_action.py
+++ b/ckanext/xloader/tests/test_action.py
@@ -14,6 +14,7 @@ from ckanext.xloader.utils import get_xloader_user_apitoken
 @pytest.mark.usefixtures("clean_db", "with_plugins")
 @pytest.mark.ckan_config("ckan.plugins", "datastore xloader")
 class TestAction(object):
+
     def test_submit(self):
         # checks that xloader_submit enqueues the resource (to be xloadered)
         user = factories.User()
@@ -117,7 +118,6 @@ class TestAction(object):
         )
 
         assert status["status"] == "pending"
-
 
     def test_xloader_user_api_token_from_config(self):
         sysadmin = factories.SysadminWithToken()

--- a/ckanext/xloader/tests/test_jobs.py
+++ b/ckanext/xloader/tests/test_jobs.py
@@ -13,7 +13,6 @@ from ckan.tests import helpers, factories
 from unittest import mock
 
 from ckanext.xloader import jobs
-from ckanext.xloader.utils import get_xloader_user_apitoken
 
 
 _TEST_FILE_CONTENT = "x, y\n1,2\n2,4\n3,6\n4,8\n5,10"

--- a/ckanext/xloader/tests/test_jobs.py
+++ b/ckanext/xloader/tests/test_jobs.py
@@ -247,7 +247,6 @@ class TestXLoaderJobs(helpers.FunctionalRQTestBase):
                 return ValueError("Test error")
             elif error_type == "TypeError":
                 return TypeError("Test error")
-
         
         def mock_download_with_error(*args, **kwargs):
             if not hasattr(mock_download_with_error, 'call_count'):

--- a/ckanext/xloader/tests/test_loader.py
+++ b/ckanext/xloader/tests/test_loader.py
@@ -716,6 +716,28 @@ class TestLoadCsv(TestLoadBase):
         ]
         assert len(self._get_records(Session, resource_id)) == 6
 
+    def test_reload_fallback(self, Session):
+        csv_filepath = get_sample_filepath("simple.csv")
+        resource = factories.Resource()
+        resource_id = resource['id']
+        loader.load_csv(
+            csv_filepath,
+            resource_id=resource_id,
+            mimetype="text/csv",
+            logger=logger,
+        )
+
+        with pytest.raises(LoaderError):
+            # Loading a file with different structure should trigger an error
+            # so we fall back to Tabulator
+            loader.load_csv(
+                get_sample_filepath("simple-with-extra-column.csv"),
+                resource_id=resource_id,
+                mimetype="text/csv",
+                allow_type_guessing=True,
+                logger=logger,
+            )
+
     @pytest.mark.skipif(
         not p.toolkit.check_ckan_version(min_version="2.7"),
         reason="Requires CKAN 2.7 - see https://github.com/ckan/ckan/pull/3557",

--- a/ckanext/xloader/tests/test_utils.py
+++ b/ckanext/xloader/tests/test_utils.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 from ckan.plugins import toolkit
 from ckanext.xloader import utils
 
+
 def test_private_modify_url_no_change():
     url = "https://ckan.example.com/dataset"
     assert utils._modify_url(url, "https://ckan.example.com") == url
@@ -15,7 +16,7 @@ def test_private_modify_url_no_change():
     ("https://ckan.example.org/resource/123", "https://ckan.example.org", "https://ckan.example.org/resource/123"),
     ("http://old-ckan.com/resource/456", "http://new-ckan.com", "http://new-ckan.com/resource/456"),
     ("https://sub.example.com/path", "https://ckan.example.com", "https://ckan.example.com/path"),
-    ("ftp://fileserver.com/file", "https://ckan.example.com", "ftp://fileserver.com/file"), ##should never happen
+    ("ftp://fileserver.com/file", "https://ckan.example.com", "ftp://fileserver.com/file"),  # should never happen
     ("https://ckan.example.org/resource/789", "https://xloader.example.org", "https://xloader.example.org/resource/789"),
     ("https://ckan.example.org/dataset/data", "https://xloader.example.org", "https://xloader.example.org/dataset/data"),
     ("https://ckan.example.org/resource/123?foo=bar", "https://xloader.example.org", "https://xloader.example.org/resource/123?foo=bar"),
@@ -61,7 +62,6 @@ def test_modify_input_url(input_url, ckan_site_url, xloader_site_url, is_altered
             assert response == expected
         else:
             assert response == input_url
-
 
 
 def test_modify_input_url_no_xloader_site():


### PR DESCRIPTION
Refine the COPY vs Tabulator behaviour:
- If fields are unchanged, truncate and reuse the datastore table.
- If field names are unchanged but types have changed, drop and recreate the table but preserve the Data Dictionary.
- If field names or counts have changed, fall back to Tabulator since we need to re-guess the types.

Also includes a Flake8 cleanup and ensuring temporary files are deleted.