### PR TITLE
Make unicode headers configurable via ckanext.xloader.unicode_headers

### DIFF
--- a/ckanext/xloader/config_declaration.yaml
+++ b/ckanext/xloader/config_declaration.yaml
@@ -71,6 +71,17 @@ groups:
 
             Strict means that a type will not be guessed if parsing fails for a single cell in the column.
         type: bool
+      - key: ckanext.xloader.unicode_headers
+        default: False
+        example: True
+        description: |
+            By default, xloader transliterates column headers to ASCII using
+            unidecode. This works well for accented Latin characters, but it
+            mangles or empties out headers written in non-Latin scripts such as
+            Hebrew, Arabic, Cyrillic or CJK. Set this option to True to keep the
+            original header text as-is (unicode) instead of transliterating it.
+        type: bool
+        required: false
       - key: ckanext.xloader.max_type_guessing_length
         default: 0
         example: 100000

--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -690,7 +690,7 @@ def encode_headers(headers):
     # For non-Latin scripts (Hebrew, Arabic, Cyrillic, CJK, ...) unidecode
     # can mangle or empty out a header entirely, so setting
     # ckanext.xloader.unicode_headers = True keeps the original text as-is.
-    if p.toolkit.asbool(config.get('ckanext.xloader.unicode_headers', False)):
+    if p.toolkit.asbool(config.get('ckanext.xloader.unicode_headers')):
         decode_func = str
     else:
         decode_func = unidecode

--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -685,12 +685,21 @@ def get_types():
 
 
 def encode_headers(headers):
+    # By default, transliterate headers to ASCII with unidecode, so that
+    # e.g. accented Latin characters are simplified rather than dropped.
+    # For non-Latin scripts (Hebrew, Arabic, Cyrillic, CJK, ...) unidecode
+    # can mangle or empty out a header entirely, so setting
+    # ckanext.xloader.unicode_headers = True keeps the original text as-is.
+    if p.toolkit.asbool(config.get('ckanext.xloader.unicode_headers', False)):
+        decode_func = str
+    else:
+        decode_func = unidecode
     encoded_headers = []
     for header in headers:
         try:
-            encoded_headers.append(unidecode(header))
+            encoded_headers.append(decode_func(header))
         except AttributeError:
-            encoded_headers.append(unidecode(str(header)))
+            encoded_headers.append(decode_func(str(header)))
 
     return encoded_headers
 

--- a/ckanext/xloader/tests/test_loader.py
+++ b/ckanext/xloader/tests/test_loader.py
@@ -817,6 +817,26 @@ class TestLoadCsv(TestLoadBase):
         assert "nom" in test_result_int_headers
         assert "3" in test_result_int_headers
 
+    def test_encode_headers_transliterates_by_default(self):
+        # By default (unicode_headers unset/False) non-Latin headers are
+        # transliterated to ASCII by unidecode, so a Hebrew header is not
+        # preserved as-is.
+        hebrew_header = u"שם"
+        result = loader.encode_headers([u"id", hebrew_header])
+
+        assert "id" in result
+        assert hebrew_header not in result
+
+    @pytest.mark.ckan_config("ckanext.xloader.unicode_headers", True)
+    def test_encode_headers_preserves_unicode_when_enabled(self):
+        # With ckanext.xloader.unicode_headers = True the original header text
+        # is kept as-is, so a Hebrew header is preserved.
+        hebrew_header = u"שם"
+        result = loader.encode_headers([u"id", hebrew_header])
+
+        assert "id" in result
+        assert hebrew_header in result
+
     def test_column_names(self, Session):
         csv_filepath = get_sample_filepath("column_names.csv")
         resource = factories.Resource()


### PR DESCRIPTION
encode_headers() previously always ran unidecode() on column headers, which transliterates or empties out non-Latin scripts (Hebrew, Arabic, Cyrillic, CJK). This adds a ckanext.xloader.unicode_headers boolean option (default False, preserving current behaviour). When True, headers are kept as-is (str) instead of being transliterated.

This modernises the approach from the OriHoch-add-support-for-unicode-headers branch, which relied on the Python 2 unicode() builtin and is broken on Python 3. Here we use p.toolkit.asbool(config.get(...)) and str.

Also declares the option in config_declaration.yaml and adds tests covering both the default transliteration behaviour and unicode preservation when enabled.