### PR TITLE
Convert to unidecode_headers and default to True

### DIFF
--- a/ckanext/xloader/config_declaration.yaml
+++ b/ckanext/xloader/config_declaration.yaml
@@ -71,15 +71,16 @@ groups:
 
             Strict means that a type will not be guessed if parsing fails for a single cell in the column.
         type: bool
-      - key: ckanext.xloader.unicode_headers
-        default: False
+      - key: ckanext.xloader.unidecode_headers
+        default: True
         example: True
         description: |
-            By default, xloader transliterates column headers to ASCII using
-            unidecode. This works well for accented Latin characters, but it
-            mangles or empties out headers written in non-Latin scripts such as
-            Hebrew, Arabic, Cyrillic or CJK. Set this option to True to keep the
-            original header text as-is (unicode) instead of transliterating it.
+            By default, xloader transliterates column headers to ASCII using 
+            unidecode. This supports accented Latin characters but may mangle 
+            non-Latin scripts (Hebrew, Arabic, Cyrillic, CJK). 
+            Set to False to leave strings as-is. 
+            Warning: Use at your own risk; When disabled: Unicode manipulation can be used 
+            to hide malware from users and AI/LLM systems.
         type: bool
         required: false
       - key: ckanext.xloader.max_type_guessing_length

--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -689,11 +689,11 @@ def encode_headers(headers):
     # e.g. accented Latin characters are simplified rather than dropped.
     # For non-Latin scripts (Hebrew, Arabic, Cyrillic, CJK, ...) unidecode
     # can mangle or empty out a header entirely, so setting
-    # ckanext.xloader.unicode_headers = True keeps the original text as-is.
-    if p.toolkit.asbool(config.get('ckanext.xloader.unicode_headers')):
-        decode_func = str
-    else:
+    # ckanext.xloader.unidecode_headers = False keeps the original text as-is.
+    if p.toolkit.asbool(config.get('ckanext.xloader.unidecode_headers', True)):
         decode_func = unidecode
+    else:
+        decode_func = str
     encoded_headers = []
     for header in headers:
         try:

--- a/ckanext/xloader/tests/test_loader.py
+++ b/ckanext/xloader/tests/test_loader.py
@@ -818,19 +818,22 @@ class TestLoadCsv(TestLoadBase):
         assert "3" in test_result_int_headers
 
     def test_encode_headers_transliterates_by_default(self):
-        # By default (unicode_headers unset/False) non-Latin headers are
-        # transliterated to ASCII by unidecode, so a Hebrew header is not
-        # preserved as-is.
         hebrew_header = u"שם"
         result = loader.encode_headers([u"id", hebrew_header])
 
         assert "id" in result
         assert hebrew_header not in result
 
-    @pytest.mark.ckan_config("ckanext.xloader.unicode_headers", True)
-    def test_encode_headers_preserves_unicode_when_enabled(self):
-        # With ckanext.xloader.unicode_headers = True the original header text
-        # is kept as-is, so a Hebrew header is preserved.
+    @pytest.mark.ckan_config("ckanext.xloader.unidecode_headers", True)
+    def test_encode_headers_transliterates_by_when_unicode_headers_true(self):
+        hebrew_header = u"שם"
+        result = loader.encode_headers([u"id", hebrew_header])
+
+        assert "id" in result
+        assert hebrew_header not in result
+
+    @pytest.mark.ckan_config("ckanext.xloader.unidecode_headers", False)
+    def test_encode_headers_preserves_unicode_when_unicode_headers_false(self):
         hebrew_header = u"שם"
         result = loader.encode_headers([u"id", hebrew_header])
 

--- a/ckanext/xloader/tests/test_loader.py
+++ b/ckanext/xloader/tests/test_loader.py
@@ -825,7 +825,7 @@ class TestLoadCsv(TestLoadBase):
         assert hebrew_header not in result
 
     @pytest.mark.ckan_config("ckanext.xloader.unidecode_headers", True)
-    def test_encode_headers_transliterates_by_when_unicode_headers_true(self):
+    def test_encode_headers_transliterates_when_unidecode_headers_true(self):
         hebrew_header = u"שם"
         result = loader.encode_headers([u"id", hebrew_header])
 


### PR DESCRIPTION
Re-reviewing https://github.com/ckan/ckanext-xloader/pull/283 

See against master for tweaks ontop of suggested feature flag: https://github.com/ckan/ckanext-xloader/compare/master...correct_behavour_for_patch 

Its better to have the feature flag mean what it does. 

Also add warning that if you don't 'convert' you can have issues. Use (as in not tested and may not be the most secure)