### PR TITLE
fix: drop trailing blank cells from wide rows in load_csv and load_table

### DIFF
--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -54,7 +54,7 @@ tabulator_config.CSV_SAMPLE_LINES = CSV_SAMPLE_LINES
 SINGLE_BYTE_ENCODING = 'cp1252'
 
 
-def _classify_extra_cell(index, cell, header_count):
+def _should_keep_cell(index, cell, header_count):
     """Decide what to do with a cell whose position may exceed the headers.
 
     Some exporters (notably Microsoft Excel) append extra empty cells to the
@@ -441,14 +441,14 @@ def load_csv(csv_filepath, resource_id, mimetype='text/csv', allow_type_guessing
         # (e.g. Excel exports that append empty trailing cells) still line up
         # with the declared columns instead of failing COPY with "extra data
         # after last expected column". A surplus cell holding real data raises
-        # a LoaderError via _classify_extra_cell rather than being dropped.
+        # a LoaderError via _should_keep_cell rather than being dropped.
         def normalize_row_iter():
             for row in super_iter():
-                # Trim trailing cells beyond the header. _classify_extra_cell
+                # Trim trailing cells beyond the header. _should_keep_cell
                 # returns False for a surplus blank (safe to drop) and raises
                 # if a surplus cell holds real data.
                 while len(row) > field_count and \
-                        not _classify_extra_cell(len(row) - 1, row[-1], field_count):
+                        not _should_keep_cell(len(row) - 1, row[-1], field_count):
                     row.pop()
 
                 if len(row) == field_count:
@@ -621,7 +621,7 @@ def load_table(table_filepath, resource_id, mimetype='text/csv', logger=None):
                 data_row = {}
                 for index, cell in enumerate(row):
                     # Ignore surplus blank cells, error on surplus real data.
-                    if not _classify_extra_cell(index, cell, header_count):
+                    if not _should_keep_cell(index, cell, header_count):
                         continue
                     data_row[headers[index]] = cell
                 yield data_row

--- a/ckanext/xloader/loader.py
+++ b/ckanext/xloader/loader.py
@@ -54,6 +54,33 @@ tabulator_config.CSV_SAMPLE_LINES = CSV_SAMPLE_LINES
 SINGLE_BYTE_ENCODING = 'cp1252'
 
 
+def _classify_extra_cell(index, cell, header_count):
+    """Decide what to do with a cell whose position may exceed the headers.
+
+    Some exporters (notably Microsoft Excel) append extra empty cells to the
+    header and/or body, so a row can be wider than the declared columns. Blank
+    header cells don't produce a column, which is why the row length no longer
+    matches the column count.
+
+    Shared by both load paths (``load_csv`` and ``load_table``) so they treat
+    surplus cells identically.
+
+    :returns: ``True`` if the cell is within the declared columns and should be
+        used, ``False`` if it is a surplus blank cell that should be ignored.
+    :raises LoaderError: if the surplus cell holds real data, since dropping it
+        would silently lose data.
+    """
+    if index < header_count:
+        return True
+    # Out of bounds. Ignore it only if it's blank; a real value here means the
+    # row genuinely has more data than the header describes.
+    if cell is None or str(cell).strip() == '':
+        return False
+    raise LoaderError(
+        "Found data in column %s but resource only has %s header(s)"
+        % (index + 1, header_count))
+
+
 class FieldMatch(Enum):
     """ Enumerates the possible match results between existing and new fields.
 
@@ -407,16 +434,30 @@ def load_csv(csv_filepath, resource_id, mimetype='text/csv', allow_type_guessing
 
     logger.info('Fields: %s', fields)
 
-    def _make_whitespace_stripping_iter(super_iter):
-        def strip_white_space_iter():
+    field_count = len(fields)
+
+    def _make_row_normalizing_iter(super_iter):
+        # Drop surplus blank cells so rows that are wider than the header
+        # (e.g. Excel exports that append empty trailing cells) still line up
+        # with the declared columns instead of failing COPY with "extra data
+        # after last expected column". A surplus cell holding real data raises
+        # a LoaderError via _classify_extra_cell rather than being dropped.
+        def normalize_row_iter():
             for row in super_iter():
-                if len(row) == len(fields):
+                # Trim trailing cells beyond the header. _classify_extra_cell
+                # returns False for a surplus blank (safe to drop) and raises
+                # if a surplus cell holds real data.
+                while len(row) > field_count and \
+                        not _classify_extra_cell(len(row) - 1, row[-1], field_count):
+                    row.pop()
+
+                if len(row) == field_count:
                     for _index, _cell in enumerate(row):
                         # only strip white space if strip_extra_white is True
                         if fields[_index].get('strip_extra_white', True) and isinstance(_cell, str):
                             row[_index] = _cell.strip()
                 yield row
-        return strip_white_space_iter
+        return normalize_row_iter
 
     # encoding (and line ending?)- use chardet
     # It is easier to reencode it as UTF8 than convert the name of the encoding
@@ -428,12 +469,12 @@ def load_csv(csv_filepath, resource_id, mimetype='text/csv', allow_type_guessing
         try:
             with UnknownEncodingStream(csv_filepath, file_format, decoding_result,
                                        skip_rows=skip_rows) as stream:
-                stream.iter = _make_whitespace_stripping_iter(stream.iter)
+                stream.iter = _make_row_normalizing_iter(stream.iter)
                 stream.save(**save_args)
         except (EncodingError, UnicodeDecodeError):
             with Stream(csv_filepath, format=file_format, encoding=SINGLE_BYTE_ENCODING,
                         skip_rows=skip_rows) as stream:
-                stream.iter = _make_whitespace_stripping_iter(stream.iter)
+                stream.iter = _make_row_normalizing_iter(stream.iter)
                 stream.save(**save_args)
         csv_filepath = f_write.name
 
@@ -579,17 +620,9 @@ def load_table(table_filepath, resource_id, mimetype='text/csv', logger=None):
             for row in stream:
                 data_row = {}
                 for index, cell in enumerate(row):
-                    # Handle files that have extra blank cells in heading and body
-                    # eg from Microsoft Excel adding lots of empty cells on export.
-                    # Blank header cells won't generate a column,
-                    # so row length won't match column count.
-                    if index >= header_count:
-                        # error if there's actual data out of bounds, otherwise ignore
-                        if cell:
-                            raise LoaderError("Found data in column %s but resource only has %s header(s)",
-                                              index + 1, header_count)
-                        else:
-                            continue
+                    # Ignore surplus blank cells, error on surplus real data.
+                    if not _classify_extra_cell(index, cell, header_count):
+                        continue
                     data_row[headers[index]] = cell
                 yield data_row
         result = row_iterator()

--- a/ckanext/xloader/tests/test_loader.py
+++ b/ckanext/xloader/tests/test_loader.py
@@ -634,6 +634,37 @@ class TestLoadCsv(TestLoadBase):
         )
         assert len(self._get_records(Session, resource_id)) == 3
 
+    def test_with_extra_blank_cells(self, Session):
+        # Rows wider than the header, padded with trailing empty cells
+        # (e.g. Excel exports). load_csv's row-normalizing iter should drop
+        # the surplus blank cells so COPY doesn't fail with "extra data after
+        # last expected column". This exercises the load_csv path; the
+        # equivalent load_table coverage lives in TestLoadTabulator.
+        csv_filepath = get_sample_filepath("sample_with_extra_blank_cells.csv")
+        resource = factories.Resource()
+        resource_id = resource['id']
+        loader.load_csv(
+            csv_filepath,
+            resource_id=resource_id,
+            mimetype="text/csv",
+            logger=logger,
+        )
+        assert len(self._get_records(Session, resource_id)) == 1
+
+    def test_with_extra_blank_cells_data_only(self, Session):
+        # Header has 3 columns; each data row carries a single trailing blank
+        # cell. The surplus blanks should be dropped and both rows loaded.
+        csv_filepath = get_sample_filepath("extra_fields.csv")
+        resource = factories.Resource()
+        resource_id = resource['id']
+        loader.load_csv(
+            csv_filepath,
+            resource_id=resource_id,
+            mimetype="text/csv",
+            logger=logger,
+        )
+        assert len(self._get_records(Session, resource_id)) == 2
+
     def test_with_empty_lines(self, Session):
         csv_filepath = get_sample_filepath("sample_with_empty_lines.csv")
         resource = factories.Resource()
@@ -1028,11 +1059,12 @@ class TestLoadUnhandledTypes(TestLoadBase):
                 mimetype="text/csv",
                 logger=logger,
             )
-        assert "Error with field definition" in str(exception.value)
-        assert (
-            '"<?xml version="1.0" encoding="utf-8" ?>" is not a valid field name'
-            in str(exception.value)
-        )
+        # The KML file parses as a single-column CSV whose body rows are wider
+        # than that one header. Surplus cells holding real data are now rejected
+        # up-front by _classify_extra_cell (see load_csv's row-normalizing iter),
+        # so the load fails here rather than later at field-definition validation.
+        assert "Found data in column" in str(exception.value)
+        assert "resource only has 1 header(s)" in str(exception.value)
 
     def test_geojson(self):
         filepath = get_sample_filepath("polling_locations.geojson")

--- a/ckanext/xloader/tests/test_loader.py
+++ b/ckanext/xloader/tests/test_loader.py
@@ -1061,7 +1061,7 @@ class TestLoadUnhandledTypes(TestLoadBase):
             )
         # The KML file parses as a single-column CSV whose body rows are wider
         # than that one header. Surplus cells holding real data are now rejected
-        # up-front by _classify_extra_cell (see load_csv's row-normalizing iter),
+        # up-front by _should_keep_cell (see load_csv's row-normalizing iter),
         # so the load fails here rather than later at field-definition validation.
         assert "Found data in column" in str(exception.value)
         assert "resource only has 1 header(s)" in str(exception.value)


### PR DESCRIPTION
## Summary

Excel and some other exporters pad every row with extra empty cells (trailing
commas). The header row ignores them, but data rows did not, so rows came out
wider than the declared columns and the DataStore `COPY` failed with
`extra data after last expected column`.

This makes data-row handling tolerant of surplus **trailing blank** cells,
matching how the header is already treated, while still rejecting surplus cells
that contain real data so we never silently drop it.

## Related

- Fixes #272 — CSV loading fails when rows have trailing empty cells.
- Relates to #274 — upstream PR addressing #272 (among other changes).
- Relates to qld-gov-au/ckanext-xloader#89 — handle empty cells past end of row.

## Changes

- Add `_classify_extra_cell(index, cell, header_count)`, a single place that
  decides how to treat a cell beyond the headers:
  - within the columns -> keep
  - surplus blank cell -> drop
  - surplus cell with real data -> raise `LoaderError`
- `load_csv`: `_make_whitespace_stripping_iter` becomes
  `_make_row_normalizing_iter`, which trims surplus trailing blank cells before
  the existing whitespace stripping so wide rows line up with the columns.
- `load_table`: reuse the same helper so both load paths behave identically.

## Behavior change

Rows whose surplus cells hold real data now fail fast with
`Found data in column N but resource only has M header(s)` instead of being
skipped or failing later. This surfaces genuinely malformed data early rather
than losing it silently.

## Tests

- `test_with_extra_blank_cells` / `test_with_extra_blank_cells_data_only` —
  rows padded with trailing empty cells load successfully via `load_csv`.
- Updated the KML unhandled-types assertions to expect the new
  `Found data in column ...` error, since a single-column CSV with real
  surplus data is now rejected up front rather than at field-definition
  validation.
